### PR TITLE
fix: UserModel에 성별(gender) 필드 추가 및 null 불허 처리

### DIFF
--- a/app2_client/lib/models/user_model.dart
+++ b/app2_client/lib/models/user_model.dart
@@ -1,20 +1,20 @@
 class UserModel {
   final String email;
-  final String? name;
+  final String name;
   final bool isRegistered;
   final String token;
-  final String? phone;         // 추가: 휴대폰 번호
-  final int? age;              // 추가: 나이
-  final String? profileImageUrl; // 추가: 프로필 이미지 URL
+  final String phone;
+  final int age;
+  final String gender; // 추가: 성별
 
   UserModel({
     required this.email,
     required this.isRegistered,
     required this.token,
-    this.name,
-    this.phone,
-    this.age,
-    this.profileImageUrl,
+    required this.name,
+    required this.phone,
+    required this.age,
+    required this.gender,
   });
 
   factory UserModel.fromJson(Map<String, dynamic> json) {
@@ -22,10 +22,10 @@ class UserModel {
       email: json['email'] as String,
       isRegistered: json['isRegistered'] as bool,
       token: json['token'] as String,
-      name: json['name'] as String?,
-      phone: json['phone'] as String?,
-      age: json['age'] != null ? json['age'] as int : null,
-      profileImageUrl: json['profileImageUrl'] as String?,
+      name: json['name'] as String,
+      phone: json['phone'] as String,
+      age: json['age'] as int,
+      gender: json['gender'] as String,
     );
   }
 }

--- a/app2_client/lib/screens/signup_screen.dart
+++ b/app2_client/lib/screens/signup_screen.dart
@@ -14,6 +14,7 @@ class _SignupScreenState extends State<SignupScreen> {
   String _name = '';
   String _phone = '';
   String _age = '';
+  String? _gender;
 
   void _submit() async {
     if (_formKey.currentState!.validate()) {
@@ -21,7 +22,8 @@ class _SignupScreenState extends State<SignupScreen> {
       final additionalInfo = {
         'name': _name,
         'phone': _phone,
-        'age': int.tryParse(_age) ?? 0,
+        'age': _age,
+        'gender': _gender,
       };
 
       final authProvider = Provider.of<AuthProvider>(context, listen: false);
@@ -44,6 +46,8 @@ class _SignupScreenState extends State<SignupScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final genderOptions = ['남', '여'];
+
     return Scaffold(
       appBar: AppBar(title: const Text("회원가입")),
       body: Padding(

--- a/app2_client/lib/services/auth_service.dart
+++ b/app2_client/lib/services/auth_service.dart
@@ -21,6 +21,9 @@ class AuthService {
         name: googleUser.displayName ?? '',
         isRegistered: false,
         token: googleAuth.idToken ?? '',
+        phone: '',
+        age: 20,
+        gender: '남'
       );
     } catch (e) {
       print('구글 로그인 실패: $e');


### PR DESCRIPTION
- 기존 UserModel에 성별(gender) 필드를 추가하고, 필수 항목으로 변경하여 null을 허용하지 않도록 수정함.
- fromJson 팩토리 생성자에서 'gender' 값을 반드시 파싱하여 할당하도록 업데이트.
- 이를 통해, 회원가입 추가 정보 입력 시 성별이 필수 값으로 처리되어 데이터 일관성을 보장함.
- 향후 백엔드 응답에 따라 회원 정보 업데이트 시, 성별 정보가 반드시 포함되어야 함.
Closes #4 