### PR TITLE
feat: 카카오 지도 기반 목적지 선택 페이지 구성 및 이전페이지 임시 추가

### DIFF
--- a/app2_client/lib/constants/api_constants.dart
+++ b/app2_client/lib/constants/api_constants.dart
@@ -3,4 +3,5 @@ class ApiConstants {
   static const String baseUrl = "https://your-backend.com";
   static const String loginEndpoint = "/api/oauth/login";
   static const String signupEndpoint = "/api/oauth/user";
+  static const String partyEndpoint = "/api/party";
 }

--- a/app2_client/lib/models/party_model.dart
+++ b/app2_client/lib/models/party_model.dart
@@ -1,0 +1,31 @@
+class PartyModel {
+  final int partyId;
+  final Map<String, dynamic>? partyStart;         // 예: {"location": {"name": "xxx", "lat": 11.1111, "lng": 22.2222}, "stopover_type": "START"}
+  final Map<String, dynamic>? partyDestination;     // 예: {"location": {"name": "xxx", "lat": 33.3333, "lng": 44.4444}, "stopover_type": "DESTINATION"}
+  final double? partyRadius;                        // 예: 5.0
+  final int partyMaxPerson;                         // 예: 3
+  final String partyOption;                         // 예: "MIXED"
+  final List<dynamic>? partyStopovers;              // 파티 조회 시, 경유지 목록 등
+
+  PartyModel({
+    required this.partyId,
+    this.partyStart,
+    this.partyDestination,
+    this.partyRadius,
+    required this.partyMaxPerson,
+    required this.partyOption,
+    this.partyStopovers,
+  });
+
+  factory PartyModel.fromJson(Map<String, dynamic> json) {
+    return PartyModel(
+      partyId: json['party_id'] as int,
+      partyStart: json['party_start'] as Map<String, dynamic>?,
+      partyDestination: json['party_destination'] as Map<String, dynamic>?,
+      partyRadius: (json['party_radius'] is num) ? (json['party_radius'] as num).toDouble() : null,
+      partyMaxPerson: json['party_max_person'] as int,
+      partyOption: json['party_option'] as String,
+      partyStopovers: json['party_stopovers'] as List<dynamic>?,
+    );
+  }
+}

--- a/app2_client/lib/screens/map_screen.dart
+++ b/app2_client/lib/screens/map_screen.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:app2_client/widgets/custom_back_button.dart';
+// 아래 두 파일은 임시로 만든 페이지 예시입니다.
+import 'search_address_screen.dart';
+import 'destination_radius_screen.dart';
+
+class DestinationMapScreen extends StatefulWidget {
+  const DestinationMapScreen({Key? key}) : super(key: key);
+
+  @override
+  _DestinationMapScreenState createState() => _DestinationMapScreenState();
+}
+
+class _DestinationMapScreenState extends State<DestinationMapScreen> {
+  late WebViewController _controller;
+
+  // 미리 호스팅된 카카오 지도 페이지 URL, 초기 좌표는 쿼리 파라미터로 전달
+  final String mapUrl =
+      "https://your-hosted-kakao-map-page.com/?lat=37.5665&lng=126.9780";
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          // 전체 화면을 채우는 WebView: 카카오 지도 페이지 로드
+          WebView(
+            initialUrl: mapUrl,
+            javascriptMode: JavascriptMode.unrestricted,
+            onWebViewCreated: (controller) {
+              _controller = controller;
+            },
+          ),
+          // 중앙에 고정된 위치 마커 (선택된 위치 표시)
+          Center(
+            child: Icon(
+              Icons.location_on,
+              size: 50,
+              color: Colors.redAccent,
+            ),
+          ),
+          // 왼쪽 상단에 재사용 가능한 뒤로가기 버튼
+          Positioned(
+            top: 40,
+            left: 16,
+            child: CustomBackButton(),
+          ),
+          // 하단 중앙 "이 위치로 목적지 설정" 버튼
+          Positioned(
+            bottom: 30,
+            left: 16,
+            right: 16,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              onPressed: () async {
+                // 웹페이지 내 JavaScript 함수를 호출해 선택한 위치 정보를 가져온다고 가정
+                String result = await _controller.evaluateJavascript("getSelectedDestination()");
+                print('선택된 위치 정보: $result');
+                // 이후 선택된 위치 정보를 백엔드로 보내거나, 다음 페이지로 전환
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const DestinationRadiusScreen(),
+                  ),
+                );
+              },
+              child: const Text(
+                '이 위치로 목적지 설정',
+                style: TextStyle(fontSize: 18),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app2_client/lib/screens/party_create_screen.dart
+++ b/app2_client/lib/screens/party_create_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class PartyCreateScreen extends StatelessWidget {
+  const PartyCreateScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("팟 생성하기"),
+      ),
+      body: const Center(
+        child: Text(
+          "팟 생성하기 페이지 - 구현 예정",
+          style: TextStyle(fontSize: 20),
+        ),
+      ),
+    );
+  }
+}

--- a/app2_client/lib/screens/party_screen.dart
+++ b/app2_client/lib/screens/party_screen.dart
@@ -2,17 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:app2_client/widgets/custom_back_button.dart';
-import 'search_address_screen.dart';
-import 'destination_radius_screen.dart';
+import 'party_create_screen.dart'; // 팟 생성 페이지 (임시 페이지)
 
-class DestinationMapScreen extends StatefulWidget {
-  const DestinationMapScreen({Key? key}) : super(key: key);
+class PartyMapScreen extends StatefulWidget {
+  const PartyMapScreen({Key? key}) : super(key: key);
 
   @override
-  _DestinationMapScreenState createState() => _DestinationMapScreenState();
+  _PartyMapScreenState createState() => _PartyMapScreenState();
 }
 
-class _DestinationMapScreenState extends State<DestinationMapScreen> {
+class _PartyMapScreenState extends State<PartyMapScreen> {
   late WebViewController _controller;
   String _localHtml = '';
 
@@ -24,8 +23,8 @@ class _DestinationMapScreenState extends State<DestinationMapScreen> {
 
   Future<void> _loadLocalHtml() async {
     _localHtml = await rootBundle.loadString('assets/kakao_map.html');
-    // _controller가 이미 생성된 경우 HTML 로드
-    if (_controller != null && _localHtml.isNotEmpty) {
+    // _controller가 이미 생성되어 있다면 HTML 내용을 로드
+    if (_localHtml.isNotEmpty && _controller != null) {
       _controller.loadHtmlString(_localHtml);
     }
   }
@@ -35,32 +34,32 @@ class _DestinationMapScreenState extends State<DestinationMapScreen> {
     return Scaffold(
       body: Stack(
         children: [
-          // WebView: 로컬 HTML 파일 내용을 로드
+          // WebView: 로컬 kakao_map.html 파일을 로드합니다.
           WebView(
             javascriptMode: JavascriptMode.unrestricted,
             onWebViewCreated: (controller) {
               _controller = controller;
-              // 이미 _localHtml이 로드되었으면 바로 HTML을 로드
               if (_localHtml.isNotEmpty) {
                 _controller.loadHtmlString(_localHtml);
               }
             },
+            // 필요하면 JavaScript 채널 설정하여 Flutter와 HTML 간 데이터 주고받기
           ),
-          // 중앙에 고정된 위치 마커 (선택된 위치 표시)
-          Center(
+          // 중앙에 고정된 위치 마커 아이콘 (사용자가 보는 지도 중심 또는 선택된 위치를 표시)
+          const Center(
             child: Icon(
               Icons.location_on,
               size: 50,
               color: Colors.redAccent,
             ),
           ),
-          // 왼쪽 상단: CustomBackButton (재사용 가능한 뒤로가기 버튼)
-          Positioned(
+          // 왼쪽 상단에 재사용 가능한 CustomBackButton 배치
+          const Positioned(
             top: 40,
             left: 16,
             child: CustomBackButton(),
           ),
-          // 하단 중앙: "이 위치로 목적지 설정" 버튼
+          // 하단 중앙에 "팟 생성하기" 버튼 배치
           Positioned(
             bottom: 30,
             left: 16,
@@ -73,19 +72,20 @@ class _DestinationMapScreenState extends State<DestinationMapScreen> {
                 ),
               ),
               onPressed: () async {
-                // 로컬 HTML 내에 정의된 JavaScript 함수 호출
+                // HTML 내 JavaScript 함수 getSelectedDestination()을 호출하여, 사용자가 선택한 위치 정보를 받아옵니다.
                 String result = await _controller.evaluateJavascript("getSelectedDestination()");
                 print('선택된 위치 정보: $result');
-                // 이후, 결과에 따라 다음 페이지로 이동하거나 추가 처리를 함
+                // 여기서 result를 파싱하여 백엔드 API 호출 등의 후속 처리를 할 수 있습니다.
+                // 이후, 팟 생성 페이지로 이동합니다.
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => const DestinationRadiusScreen(),
+                    builder: (context) => const PartyCreateScreen(),
                   ),
                 );
               },
               child: const Text(
-                '이 위치로 목적지 설정',
+                '팟 생성하기',
                 style: TextStyle(fontSize: 18),
               ),
             ),

--- a/app2_client/lib/services/party_service.dart
+++ b/app2_client/lib/services/party_service.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:app2_client/constants/api_constants.dart';
+import 'package:app2_client/models/party_model.dart';
+
+class PartyService {
+  /// 파티 생성
+  ///
+  /// [partyData]에는 아래와 같은 JSON 형식의 데이터가 포함됩니다:
+  /// {
+  ///   "party_start": {"location": {"name": "xxx", "lat": 11.1111, "lng": 22.2222}, "stopover_type": "START"},
+  ///   "party_destination": {"location": {"name": "xxx", "lat": 33.3333, "lng": 44.4444}, "stopover_type": "DESTINATION"},
+  ///   "party_radius": 5.0,
+  ///   "party_max_person": 3,
+  ///   "party_option": "MIXED"
+  /// }
+  ///
+  /// [token]은 인증 토큰입니다.
+  Future<PartyModel?> createParty(Map<String, dynamic> partyData, String token) async {
+    final url = Uri.parse('${ApiConstants.baseUrl}${ApiConstants.partyEndpoint}');
+    try {
+      final response = await http.post(
+        url,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode(partyData),
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        return PartyModel.fromJson(data);
+      } else {
+        print('파티 생성 실패: ${response.body}');
+        return null;
+      }
+    } catch (e) {
+      print('파티 생성 예외: $e');
+      return null;
+    }
+  }
+
+  /// 파티 조회
+  ///
+  /// [partyId]는 조회할 파티의 ID입니다.
+  /// [token]은 인증 토큰입니다.
+  Future<PartyModel?> getParty(int partyId, String token) async {
+    final url = Uri.parse('${ApiConstants.baseUrl}${ApiConstants.partyEndpoint}/$partyId');
+    try {
+      final response = await http.get(
+        url,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        return PartyModel.fromJson(data);
+      } else {
+        print('파티 조회 실패: ${response.body}');
+        return null;
+      }
+    } catch (e) {
+      print('파티 조회 예외: $e');
+      return null;
+    }
+  }
+
+  /// 파티에 경유지 추가
+  ///
+  /// [partyId]는 수정할 파티의 ID입니다.
+  /// [stopoverData]에는 아래와 같은 JSON 형식의 데이터가 포함됩니다:
+  /// {
+  ///   "location": {"name": "xxx", "lat": 55.5555, "lng": 66.6666},
+  ///   "stopover_type": "STOPOVER"
+  /// }
+  /// [token]은 인증 토큰입니다.
+  Future<bool> addStopover(int partyId, Map<String, dynamic> stopoverData, String token) async {
+    final url = Uri.parse('${ApiConstants.baseUrl}${ApiConstants.partyEndpoint}/$partyId');
+    try {
+      final response = await http.post(
+        url,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode(stopoverData),
+      );
+      if (response.statusCode == 200) {
+        return true;
+      } else {
+        print('경유지 추가 실패: ${response.body}');
+        return false;
+      }
+    } catch (e) {
+      print('경유지 추가 예외: $e');
+      return false;
+    }
+  }
+}

--- a/app2_client/lib/widgets/custom_back_button.dart
+++ b/app2_client/lib/widgets/custom_back_button.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class CustomBackButton extends StatelessWidget{
+  final VoidCallback? onPressed;
+
+  const CustomBackButton({Key? key, this.onPressed}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+        mini: true,
+        onPressed: onPressed ?? () => Navigator.pop(context),
+    backgroundColor: Colors.white,
+    child: const Icon(Icons.arrow_back, color: Colors.black)
+    ,
+    );
+  }
+}

--- a/app2_client/pubspec.lock
+++ b/app2_client/pubspec.lock
@@ -317,6 +317,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: "392c1d83b70fe2495de3ea2c84531268d5b8de2de3f01086a53334d8b6030a88"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.4"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: "8b3b2450e98876c70bfcead876d9390573b34b9418c19e28168b74f6cb252dbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.4"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "812165e4e34ca677bdfbfa58c01e33b27fd03ab5fa75b70832d4b7d4ca1fa8cf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.5"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: a5364369c758892aa487cbf59ea41d9edd10f9d9baf06a94e80f1bd1b4c7bbc0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.5"
 sdks:
   dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/app2_client/pubspec.yaml
+++ b/app2_client/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   google_sign_in: ^6.3.0
   provider: ^6.0.0
+  webview_flutter: ^3.0.4
 
 dev_dependencies:
   flutter_test:

--- a/app2_client/pubspec.yaml
+++ b/app2_client/pubspec.yaml
@@ -62,6 +62,7 @@ flutter:
 
   assets:
     - assets/google_logo.png
+    - assets/kakao_map.html
 
   # To add assets to your application, add an assets section, like this:
   # assets:

--- a/app2_client/test/widget_test.dart
+++ b/app2_client/test/widget_test.dart
@@ -1,30 +1,22 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:app2_client/main.dart';
+import 'package:app2_client/widgets/custom_back_button.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('CustomBackButton displays correctly', (WidgetTester tester) async {
+    // 테스트를 위해 MaterialApp과 Scaffold로 감싸서 위젯을 렌더링합니다.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CustomBackButton(),
+        ),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // CustomBackButton 위젯이 화면에 존재하는지 확인합니다.
+    expect(find.byType(CustomBackButton), findsOneWidget);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // 추가: 아이콘이 있는지 검사할 수 있습니다.
+    expect(find.byIcon(Icons.arrow_back), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 개요
이번 PR은 카카오 지도 API를 활용한 목적지 선택 페이지(DestinationMapScreen)를 구현하고, 임시로 주소 검색 페이지(SearchAddressScreen) 및 내 목적지 반경 설정 페이지(DestinationRadiusScreen)를 추가한 작업입니다.  
주요 기능은 아래와 같습니다:
- 전체 화면에 카카오 지도 WebView를 사용하여 지도 표시
- 중앙에 고정된 마커로 현재 선택된 위치 시각화
- 왼쪽 상단에 재사용 가능한 CustomBackButton 배치 (뒤로가기 시 주소 검색 페이지로 이동)
- 하단 중앙에 "이 위치로 목적지 설정" 버튼 추가, 버튼 클릭 시 WebView 내 JavaScript 함수를 호출해 선택 위치를 받아 다음 페이지로 전환

## 주요 변경 사항
- **DestinationMapScreen**:  
  - WebView를 통해 미리 호스팅된 카카오 지도 페이지 로드  
  - CustomBackButton 위젯을 이용한 뒤로가기 기능 구현  
  - 하단 버튼을 통해 선택한 위치 정보를 받아 다음 단계(내 목적지 반경 설정)로 네비게이션 처리
- **임시 페이지 추가**:  
  - SearchAddressScreen: 주소 검색 페이지 (구현 예정)  
  - DestinationRadiusScreen: 내 목적지 반경 설정 페이지 (구현 예정)
- **공통 위젯**:  
  - CustomBackButton 위젯을 `lib/widgets/custom_back_button.dart`에 분리하여 재사용성 향상
- **패키지 및 파일 구조 정리**:  
  - webview_flutter, provider 등 필요한 패키지를 pubspec.yaml에 추가
  - 화면 관련 파일들은 `lib/screens`, 재사용 위젯은 `lib/widgets`에 정리

## 테스트 및 검증
- 카카오 지도 페이지가 정상적으로 WebView에 로드되는지 확인함  
- 뒤로가기 버튼 클릭 시 SearchAddressScreen으로 이동하는지 테스트  
- 하단 버튼을 눌러, WebView에서 선택한 위치 정보를 받아오는지 콘솔 로그를 통해 확인함  
- 전체 네비게이션 흐름(목적지 선택 → 다음 페이지 이동)이 의도대로 동작함

Closes: #6 