### PR TITLE
feat: 내 파티 정보 페이지 생성 및 파티 생성 후 자동 이동 연동

### DIFF
--- a/app2_client/lib/models/party_detail_model.dart
+++ b/app2_client/lib/models/party_detail_model.dart
@@ -44,16 +44,22 @@ class PartyDetail {
   });
 
   factory PartyDetail.fromJson(Map<String, dynamic> json) {
-    final memberList = (json['party_members'] as List)
-        .map((m) => PartyMember.fromJson(m))
-        .toList();
+    final originAddress =
+        json['party_start']?['location']?['address'] ?? '출발지 정보 없음';
+    final destAddress =
+        json['party_destination']?['location']?['address'] ?? '도착지 정보 없음';
+
+    final memberList = (json['party_members'] as List<dynamic>?)
+        ?.map((m) => PartyMember.fromJson(m))
+        .toList() ??
+        [];
 
     return PartyDetail(
       partyId: json['party_id'],
-      originAddress: json['origin'] ?? '출발지 정보 없음',
-      destAddress: json['destination'] ?? '도착지 정보 없음',
+      originAddress: originAddress,
+      destAddress: destAddress,
       radius: (json['party_radius'] as num).toDouble(),
-      maxPerson: json['party_max_person'],
+      maxPerson: json['party_max_people'],
       partyOption: json['party_option'],
       members: memberList,
     );

--- a/app2_client/lib/models/party_detail_model.dart
+++ b/app2_client/lib/models/party_detail_model.dart
@@ -1,0 +1,61 @@
+class PartyMember {
+  final int id;
+  final String name;
+  final String email;
+  final String gender;
+  final String role;
+
+  PartyMember({
+    required this.id,
+    required this.name,
+    required this.email,
+    required this.gender,
+    required this.role,
+  });
+
+  factory PartyMember.fromJson(Map<String, dynamic> json) {
+    return PartyMember(
+      id: json['id'],
+      name: json['name'],
+      email: json['email'],
+      gender: json['gender'],
+      role: json['role'],
+    );
+  }
+}
+
+class PartyDetail {
+  final int partyId;
+  final String originAddress;
+  final String destAddress;
+  final double radius;
+  final int maxPerson;
+  final String partyOption;
+  final List<PartyMember> members;
+
+  PartyDetail({
+    required this.partyId,
+    required this.originAddress,
+    required this.destAddress,
+    required this.radius,
+    required this.maxPerson,
+    required this.partyOption,
+    required this.members,
+  });
+
+  factory PartyDetail.fromJson(Map<String, dynamic> json) {
+    final memberList = (json['party_members'] as List)
+        .map((m) => PartyMember.fromJson(m))
+        .toList();
+
+    return PartyDetail(
+      partyId: json['party_id'],
+      originAddress: json['origin'] ?? '출발지 정보 없음',
+      destAddress: json['destination'] ?? '도착지 정보 없음',
+      radius: (json['party_radius'] as num).toDouble(),
+      maxPerson: json['party_max_person'],
+      partyOption: json['party_option'],
+      members: memberList,
+    );
+  }
+}

--- a/app2_client/lib/screens/my_party_screen.dart
+++ b/app2_client/lib/screens/my_party_screen.dart
@@ -1,57 +1,116 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-
 import '../models/party_detail_model.dart';
-import '../providers/auth_provider.dart';
-import '../services/party_service.dart';
 
 class MyPartyScreen extends StatelessWidget {
-  const MyPartyScreen({super.key});
+  final PartyDetail party;
+
+  const MyPartyScreen({super.key, required this.party});
 
   @override
   Widget build(BuildContext context) {
-    final token = context.read<AuthProvider>().tokens?.accessToken;
-
-    if (token == null) {
-      return const Center(child: Text('로그인이 필요합니다.'));
-    }
-
     return Scaffold(
       appBar: AppBar(title: const Text('내 파티')),
-      body: FutureBuilder<PartyDetail?>(
-        future: PartyService.getMyParty(token),
-        builder: (context, snapshot) {
-          if (!snapshot.hasData) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          final party = snapshot.data!;
-          return Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('출발지: ${party.originAddress}'),
-                Text('도착지: ${party.destAddress}'),
-                Text('반경: ${party.radius}km'),
-                Text('최대 인원: ${party.maxPerson}명'),
-                Text('옵션: ${party.partyOption}'),
-                const SizedBox(height: 16),
-                Text('참여자 목록', style: const TextStyle(fontWeight: FontWeight.bold)),
-                const Divider(),
-                ...party.members.map((m) => ListTile(
-                  title: Text(m.name),
-                  subtitle: Text('${m.email} (${m.role})'),
-                  leading: Icon(
-                    m.gender == 'FEMALE' ? Icons.female : Icons.male,
-                    color: m.gender == 'FEMALE' ? Colors.pink : Colors.blue,
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 목적지 카드
+            Container(
+              decoration: BoxDecoration(
+                color: Colors.grey[200],
+                borderRadius: BorderRadius.circular(12),
+              ),
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('목적지', style: TextStyle(fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 4),
+                  Text(party.destAddress),
+                  const SizedBox(height: 12),
+                  const Center(
+                    child: Icon(Icons.location_on, size: 48, color: Colors.amber),
                   ),
-                )),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // 설명
+            const Text(
+              '서면까지 갈 사람 구해요 ~! (간단한 설명)',
+              style: TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 12),
+
+            // 해시태그
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: [
+                _tag('#${party.maxPerson}인팟'),
+                _tag(party.partyOption == 'MIXED' ? '#혼성' : '#동성만'),
+                _tag('#친절'),
+                _tag('#시간엄수'),
               ],
             ),
-          );
-        },
+            const SizedBox(height: 16),
+
+            // 방장 정보
+            Text(
+              '방장 평점: 3.2',
+              style: TextStyle(color: Colors.orange[800], fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            const Divider(),
+
+            // 파티원 목록
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('파티원', style: TextStyle(fontWeight: FontWeight.bold)),
+                Text('모집중 ${party.members.length} / ${party.maxPerson}명'),
+              ],
+            ),
+            const SizedBox(height: 12),
+            ...party.members.map((m) => Card(
+              elevation: 1,
+              child: ListTile(
+                leading: const CircleAvatar(backgroundColor: Colors.grey),
+                title: Text(m.name),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('목적지 서면 삼정타워'), // 추후 동적으로 교체 가능
+                    Text('평점 3.5'),
+                  ],
+                ),
+              ),
+            )),
+            const SizedBox(height: 24),
+
+            // 채팅방 버튼
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.blue[900]),
+                child: const Text('파티원 채팅방 가기'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
+
+  Widget _tag(String label) => Container(
+    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+    decoration: BoxDecoration(
+      color: Colors.grey[300],
+      borderRadius: BorderRadius.circular(20),
+    ),
+    child: Text(label, style: const TextStyle(fontSize: 12)),
+  );
 }

--- a/app2_client/lib/screens/my_party_screen.dart
+++ b/app2_client/lib/screens/my_party_screen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/party_detail_model.dart';
+import '../providers/auth_provider.dart';
+import '../services/party_service.dart';
+
+class MyPartyScreen extends StatelessWidget {
+  const MyPartyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final token = context.read<AuthProvider>().tokens?.accessToken;
+
+    if (token == null) {
+      return const Center(child: Text('로그인이 필요합니다.'));
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('내 파티')),
+      body: FutureBuilder<PartyDetail?>(
+        future: PartyService.getMyParty(token),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final party = snapshot.data!;
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('출발지: ${party.originAddress}'),
+                Text('도착지: ${party.destAddress}'),
+                Text('반경: ${party.radius}km'),
+                Text('최대 인원: ${party.maxPerson}명'),
+                Text('옵션: ${party.partyOption}'),
+                const SizedBox(height: 16),
+                Text('참여자 목록', style: const TextStyle(fontWeight: FontWeight.bold)),
+                const Divider(),
+                ...party.members.map((m) => ListTile(
+                  title: Text(m.name),
+                  subtitle: Text('${m.email} (${m.role})'),
+                  leading: Icon(
+                    m.gender == 'FEMALE' ? Icons.female : Icons.male,
+                    color: m.gender == 'FEMALE' ? Colors.pink : Colors.blue,
+                  ),
+                )),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/app2_client/lib/services/party_service.dart
+++ b/app2_client/lib/services/party_service.dart
@@ -7,6 +7,8 @@ import 'package:app2_client/constants/api_constants.dart';
 import 'package:app2_client/models/party_model.dart';
 import 'package:app2_client/models/party_create_request.dart';
 
+import '../models/party_detail_model.dart';
+
 class PartyService {
   /// 주변 팟 조회
   static Future<List<PartyModel>> fetchNearbyParties({
@@ -107,6 +109,31 @@ class PartyService {
 
     if (response.statusCode != 200) {
       throw Exception('파티 참여 실패: ${response.body}');
+    }
+  }
+
+  static Future<PartyDetail?> getMyParty(String accessToken) async {
+    final uri = Uri.parse('${ApiConstants.baseUrl}/api/party/my');
+
+    try {
+      final res = await http.get(
+        uri,
+        headers: {
+          'Authorization': 'Bearer $accessToken',
+          'Content-Type': 'application/json',
+        },
+      );
+
+      if (res.statusCode == 200) {
+        final json = jsonDecode(res.body);
+        return PartyDetail.fromJson(json);
+      } else {
+        debugPrint('❌ getMyParty 실패: ${res.statusCode}');
+        return null;
+      }
+    } catch (e) {
+      debugPrint('❌ getMyParty 예외: $e');
+      return null;
     }
   }
 }

--- a/app2_client/lib/services/party_service.dart
+++ b/app2_client/lib/services/party_service.dart
@@ -1,13 +1,11 @@
-// lib/services/party_service.dart
-
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
+
 import 'package:app2_client/constants/api_constants.dart';
 import 'package:app2_client/models/party_model.dart';
 import 'package:app2_client/models/party_create_request.dart';
-
-import '../models/party_detail_model.dart';
+import 'package:app2_client/models/party_detail_model.dart';
 
 class PartyService {
   /// 주변 팟 조회
@@ -60,8 +58,8 @@ class PartyService {
     }
   }
 
-  /// 파티 생성
-  static Future<void> createParty({
+  /// ✅ 파티 생성 (응답을 PartyDetail로 반환)
+  static Future<PartyDetail> createParty({
     required PartyCreateRequest request,
     required String accessToken,
   }) async {
@@ -86,6 +84,8 @@ class PartyService {
       }
 
       debugPrint('✅ 파티 생성 성공: ${response.body}');
+      final json = jsonDecode(response.body);
+      return PartyDetail.fromJson(json); // ✅ 응답을 모델로 변환하여 리턴
     } catch (e) {
       debugPrint('❌ 파티 생성 중 에러: $e');
       rethrow;
@@ -112,6 +112,7 @@ class PartyService {
     }
   }
 
+  /// 내가 만든 파티 조회 (백엔드에서 API 준비된 경우)
   static Future<PartyDetail?> getMyParty(String accessToken) async {
     final uri = Uri.parse('${ApiConstants.baseUrl}/api/party/my');
 

--- a/app2_client/lib/widgets/party_create_modal.dart
+++ b/app2_client/lib/widgets/party_create_modal.dart
@@ -1,3 +1,4 @@
+import 'package:app2_client/screens/my_party_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:app2_client/models/party_create_request.dart';
@@ -57,9 +58,17 @@ class _PartyCreateModalState extends State<PartyCreateModal> {
     try {
       await PartyService.createParty(request: req, accessToken: token);
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('파티가 생성되었습니다!')));
         Navigator.pop(context);
+
+        // 내 파티 페이지로 이동
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const MyPartyScreen()),
+        );
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('파티가 생성되었습니다')),
+        );
       }
     } catch (_) {
       ScaffoldMessenger.of(context)

--- a/app2_client/lib/widgets/party_create_modal.dart
+++ b/app2_client/lib/widgets/party_create_modal.dart
@@ -4,12 +4,13 @@ import 'package:provider/provider.dart';
 import 'package:app2_client/models/party_create_request.dart';
 import 'package:app2_client/services/party_service.dart';
 import 'package:app2_client/providers/auth_provider.dart';
+import 'package:app2_client/models/party_detail_model.dart'; // PartyDetail import 필요
 
 class PartyCreateModal extends StatefulWidget {
   final double startLat, startLng;
-  final String  startAddress;
+  final String startAddress;
   final double destLat, destLng;
-  final String  destAddress;
+  final String destAddress;
 
   const PartyCreateModal({
     super.key,
@@ -26,9 +27,9 @@ class PartyCreateModal extends StatefulWidget {
 }
 
 class _PartyCreateModalState extends State<PartyCreateModal> {
-  double  _radius    = 1000;   // m
-  int     _maxPerson = 3;
-  String  _option    = 'MIXED';
+  double _radius = 1000; // m
+  int _maxPerson = 3;
+  String _option = 'MIXED';
 
   Future<void> _submit() async {
     final token = context.read<AuthProvider>().tokens?.accessToken;
@@ -56,29 +57,30 @@ class _PartyCreateModalState extends State<PartyCreateModal> {
     );
 
     try {
-      await PartyService.createParty(request: req, accessToken: token);
-      if (mounted) {
-        Navigator.pop(context);
+      final party = await PartyService.createParty(
+        request: req,
+        accessToken: token,
+      ); // 🎯 응답 받은 PartyDetail
 
-        // 내 파티 페이지로 이동
+      if (mounted) {
+        Navigator.pop(context); // 모달 닫기
         Navigator.push(
           context,
-          MaterialPageRoute(builder: (_) => const MyPartyScreen()),
+          MaterialPageRoute(builder: (_) => MyPartyScreen(party: party)),
         );
-
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('파티가 생성되었습니다')),
         );
       }
-    } catch (_) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('파티 생성 실패')));
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('파티 생성 실패: $e')),
+      );
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    // 바텀시트 안쪽은 스크롤 가능하도록 SingleChildScrollView
     return SafeArea(
       child: SingleChildScrollView(
         padding: EdgeInsets.only(
@@ -99,28 +101,25 @@ class _PartyCreateModalState extends State<PartyCreateModal> {
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
-            const Text('파티 생성', style: TextStyle(
-                fontSize: 18, fontWeight: FontWeight.bold)),
+            const Text('파티 생성',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
             const SizedBox(height: 20),
-
-            Align(alignment: Alignment.centerLeft,
-                child: Text('출발: ${widget.startAddress}')),
-            Align(alignment: Alignment.centerLeft,
-                child: Text('도착: ${widget.destAddress}')),
+            Align(alignment: Alignment.centerLeft, child: Text('출발: ${widget.startAddress}')),
+            Align(alignment: Alignment.centerLeft, child: Text('도착: ${widget.destAddress}')),
             const Divider(height: 32),
 
             // 반경
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text('반경: ${(_radius/1000).toStringAsFixed(1)} km'),
+                Text('반경: ${(_radius / 1000).toStringAsFixed(1)} km'),
                 Expanded(
                   child: Slider(
-                    min: 1000,            // 1km
-                    max: 10000,           // 10km
+                    min: 1000,
+                    max: 10000,
                     divisions: 9,
                     value: _radius,
-                    label: '${(_radius/1000).toStringAsFixed(1)} km',
+                    label: '${(_radius / 1000).toStringAsFixed(1)} km',
                     onChanged: (v) => setState(() => _radius = v),
                   ),
                 ),
@@ -134,9 +133,9 @@ class _PartyCreateModalState extends State<PartyCreateModal> {
                 const Text('최대 인원'),
                 DropdownButton<int>(
                   value: _maxPerson,
-                  items: [1,2,3,4]
-                      .map((n) => DropdownMenuItem(
-                      value: n, child: Text('$n명'))).toList(),
+                  items: [1, 2, 3, 4]
+                      .map((n) => DropdownMenuItem(value: n, child: Text('$n명')))
+                      .toList(),
                   onChanged: (v) => setState(() => _maxPerson = v!),
                 ),
               ],
@@ -149,10 +148,11 @@ class _PartyCreateModalState extends State<PartyCreateModal> {
                 const Text('팟 옵션'),
                 DropdownButton<String>(
                   value: _option,
-                  items: ['MIXED','ONLY']
+                  items: ['MIXED', 'ONLY']
                       .map((o) => DropdownMenuItem(
-                      value: o,
-                      child: Text(o=='MIXED' ? '혼성' : '동성만')))
+                    value: o,
+                    child: Text(o == 'MIXED' ? '혼성' : '동성만'),
+                  ))
                       .toList(),
                   onChanged: (v) => setState(() => _option = v!),
                 ),
@@ -165,7 +165,8 @@ class _PartyCreateModalState extends State<PartyCreateModal> {
               child: ElevatedButton(
                 onPressed: _submit,
                 style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 14)),
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                ),
                 child: const Text('생성하기'),
               ),
             ),


### PR DESCRIPTION
- 내 파티 정보 페이지 구현
- 파티생성 완료시 내 파티정보 페이지로 이동 구현
- 생성된 파티에 참가신청후 수락할 시 자동 백엔드 호출기능 추가(추후 예정)
<img width="518" alt="image" src="https://github.com/user-attachments/assets/4dbb9ac5-8024-4450-8c4f-23c042b78d0d" />
임시 page