### PR TITLE
[feat] 경유지 및 정산자 기능 추가

### DIFF
--- a/app2_client/assets/kakao_map.html
+++ b/app2_client/assets/kakao_map.html
@@ -1,18 +1,18 @@
+<!-- assets/kakao_map.html -->
 <!DOCTYPE html>
 <html lang="ko">
 <head>
     <meta charset="UTF-8" />
-    <title>지도 띄우기</title>
+    <title>파티 목적지 선택</title>
 </head>
 <body>
 <div id="map" style="width:100%; height:100vh;"></div>
 
-<!-- Kakao Maps SDK -->
-<script
-        src="https://dapi.kakao.com/v2/maps/sdk.js?appkey={{KAKAO_JS_KEY}}&libraries=services">
-</script>
+<!-- Kakao Maps SDK: 실제 발급받은 JavaScript Key를 {{KAKAO_JS_KEY}} 자리에 넣어야 합니다. -->
+<script src="https://dapi.kakao.com/v2/maps/sdk.js?appkey={{KAKAO_JS_KEY}}&libraries=services"></script>
 
 <script>
+    // Flutter 코드에서 치환해 넣어 주는 초기 중심 좌표
     let map;
     let selectedLatLng = { lat: {{LAT}}, lng: {{LNG}} };
 
@@ -20,40 +20,23 @@
       const container = document.getElementById('map');
       const options = {
         center: new kakao.maps.LatLng(selectedLatLng.lat, selectedLatLng.lng),
-        level: 4  // 기본 줌 레벨
+        level: 4  // 초기 줌 레벨
       };
       map = new kakao.maps.Map(container, options);
 
-      // 클릭 시 목적지 좌표 저장
+      // 클릭 시 selectedLatLng에 최신 좌표를 덮어쓴다
       kakao.maps.event.addListener(map, 'click', function (mouseEvent) {
         const ll = mouseEvent.latLng;
         selectedLatLng = { lat: ll.getLat(), lng: ll.getLng() };
       });
     };
 
-    // Flutter에서 호출: 목적지 좌표 반환
+    // Flutter → JS 호출: 현재 선택된 좌표(JSON)를 반환
     window.getSelectedDestination = function () {
       return JSON.stringify(selectedLatLng);
     };
 
-    // Flutter에서 호출: 파티 마커 추가
-    window.addMarker = function(id, lat, lng, title) {
-      const position = new kakao.maps.LatLng(lat, lng);
-      const marker = new kakao.maps.Marker({
-        map: map,
-        position: position,
-        title: title,
-        image: new kakao.maps.MarkerImage(
-          'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_blue.png',
-          new kakao.maps.Size(36, 54),
-          { offset: new kakao.maps.Point(18, 54) }
-        )
-      });
-
-      kakao.maps.event.addListener(marker, 'click', function() {
-        MarkerClick.postMessage(JSON.stringify({ id: id, lat: lat, lng: lng }));
-      });
-    };
+    // (참고) 파티 생성 시에는 마커가 필요 없으므로 addMarker 함수는 생략하거나 그냥 두어도 무방합니다.
 </script>
 </body>
 </html>

--- a/app2_client/assets/kakao_party_map.html
+++ b/app2_client/assets/kakao_party_map.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>파티 지도 보기</title>
+</head>
+<body>
+<div id="map" style="width:100%; height:100vh;"></div>
+
+<!-- Kakao Maps SDK (libraries=services) -->
+<script
+        src="https://dapi.kakao.com/v2/maps/sdk.js?appkey={{KAKAO_JS_KEY}}&libraries=services">
+</script>
+
+<script>
+    let map;
+    // Flutter 쪽에서 중심 좌표(LAT, LNG)를 치환해서 넣어 줘야 합니다.
+    let centerLat = {{CENTER_LAT}};
+    let centerLng = {{CENTER_LNG}};
+
+    // 마커들을 관리하기 위한 객체
+    const markers = {};
+
+    window.onload = function () {
+      const container = document.getElementById('map');
+      const options = {
+        center: new kakao.maps.LatLng(centerLat, centerLng),
+        level: 4
+      };
+      map = new kakao.maps.Map(container, options);
+    };
+
+    // Flutter에서 호출: 마커 추가
+    // id: String, lat: Number, lng: Number, title: String, color: "blue"/"red"/"green" 등
+    window.addMarker = function (id, lat, lng, title, color) {
+      // 이미 같은 id의 마커가 있으면 제거
+      if (markers[id]) {
+        markers[id].setMap(null);
+        delete markers[id];
+      }
+
+      const position = new kakao.maps.LatLng(lat, lng);
+      // 컬러별 이미지 URL 설정 (기본 제공 마커 이미지를 대체)
+      let imageUrl;
+      switch (color) {
+        case 'red':
+          imageUrl = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_red.png';
+          break;
+        case 'green':
+          imageUrl = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_green.png';
+          break;
+        case 'blue':
+        default:
+          imageUrl = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_blue.png';
+      }
+      const imageSize = new kakao.maps.Size(36, 54);
+      const imageOption = { offset: new kakao.maps.Point(18, 54) };
+
+      const markerImage = new kakao.maps.MarkerImage(imageUrl, imageSize, imageOption);
+      const marker = new kakao.maps.Marker({
+        map: map,
+        position: position,
+        title: title,
+        image: markerImage
+      });
+
+      // 마커 클릭 시 Flutter로 메시지 전달(필요할 때만 사용)
+      kakao.maps.event.addListener(marker, 'click', function () {
+        // 예: Flutter 쪽에서 `onMarkerClick` 핸들러를 정의해 두면, 호출해 줄 수 있습니다.
+        if (window.flutter_inappwebview) {
+          window.flutter_inappwebview.callHandler('onMarkerClick', id);
+        }
+      });
+
+      markers[id] = marker;
+    };
+
+    // Flutter에서 호출: 특정 id의 마커를 제거
+    window.removeMarker = function (id) {
+      if (markers[id]) {
+        markers[id].setMap(null);
+        delete markers[id];
+      }
+    };
+
+    // Flutter에서 호출: 지도 중심을 재설정
+    window.setCenter = function (lat, lng) {
+      if (!map) return;
+      const centerPos = new kakao.maps.LatLng(lat, lng);
+      map.setCenter(centerPos);
+    };
+</script>
+</body>
+</html>

--- a/app2_client/lib/models/join_request_model.dart
+++ b/app2_client/lib/models/join_request_model.dart
@@ -1,0 +1,16 @@
+// MyPartyScreen.dart 내부에 inline으로 정의된 JoinRequest
+class JoinRequest {
+  final int requestId;
+  final String userName;
+  final String userEmail;
+
+  JoinRequest({required this.requestId, required this.userName, required this.userEmail});
+
+  factory JoinRequest.fromJson(Map<String, dynamic> json) {
+    return JoinRequest(
+      requestId: json['request_id'],
+      userName: json['name'],
+      userEmail: json['email'],
+    );
+  }
+}

--- a/app2_client/lib/models/location_model.dart
+++ b/app2_client/lib/models/location_model.dart
@@ -1,20 +1,29 @@
 // lib/models/location_model.dart
+
 class LocationModel {
-  final String name;
+  final String address;
   final double lat;
   final double lng;
 
-  LocationModel({ required this.name, required this.lat, required this.lng });
+  LocationModel({
+    required this.address,
+    required this.lat,
+    required this.lng,
+  });
 
-  factory LocationModel.fromJson(Map<String, dynamic> json) => LocationModel(
-    name: json['name'] as String,
-    lat:  (json['lat']  as num).toDouble(),
-    lng:  (json['lng']  as num).toDouble(),
-  );
+  factory LocationModel.fromJson(Map<String, dynamic> json) {
+    return LocationModel(
+      address: json['address'] as String,
+      lat: (json['lat'] as num).toDouble(),
+      lng: (json['lng'] as num).toDouble(),
+    );
+  }
 
-  Map<String, dynamic> toJson() => {
-    'name': name,
-    'lat' : lat,
-    'lng' : lng,
-  };
+  Map<String, dynamic> toJson() {
+    return {
+      'address': address,
+      'lat': lat,
+      'lng': lng,
+    };
+  }
 }

--- a/app2_client/lib/models/party_detail_model.dart
+++ b/app2_client/lib/models/party_detail_model.dart
@@ -1,28 +1,6 @@
-class PartyMember {
-  final int id;
-  final String name;
-  final String email;
-  final String gender;
-  final String role;
+// lib/models/party_detail_model.dart
 
-  PartyMember({
-    required this.id,
-    required this.name,
-    required this.email,
-    required this.gender,
-    required this.role,
-  });
-
-  factory PartyMember.fromJson(Map<String, dynamic> json) {
-    return PartyMember(
-      id: json['id'],
-      name: json['name'],
-      email: json['email'],
-      gender: json['gender'],
-      role: json['role'],
-    );
-  }
-}
+import 'party_member_model.dart';
 
 class PartyDetail {
   final int partyId;
@@ -50,17 +28,17 @@ class PartyDetail {
         json['party_destination']?['location']?['address'] ?? '도착지 정보 없음';
 
     final memberList = (json['party_members'] as List<dynamic>?)
-        ?.map((m) => PartyMember.fromJson(m))
+        ?.map((m) => PartyMember.fromJson(m as Map<String, dynamic>))
         .toList() ??
         [];
 
     return PartyDetail(
-      partyId: json['party_id'],
+      partyId: json['party_id'] as int,
       originAddress: originAddress,
       destAddress: destAddress,
       radius: (json['party_radius'] as num).toDouble(),
-      maxPerson: json['party_max_people'],
-      partyOption: json['party_option'],
+      maxPerson: json['party_max_people'] as int,
+      partyOption: json['party_option'] as String,
       members: memberList,
     );
   }

--- a/app2_client/lib/models/party_detail_model.dart
+++ b/app2_client/lib/models/party_detail_model.dart
@@ -1,6 +1,7 @@
 // lib/models/party_detail_model.dart
 
 import 'party_member_model.dart';
+import 'stopover_model.dart';
 
 class PartyDetail {
   final int partyId;
@@ -10,6 +11,7 @@ class PartyDetail {
   final int maxPerson;
   final String partyOption;
   final List<PartyMember> members;
+  final List<StopoverResponse> stopovers; // ← 추가
 
   PartyDetail({
     required this.partyId,
@@ -19,6 +21,7 @@ class PartyDetail {
     required this.maxPerson,
     required this.partyOption,
     required this.members,
+    required this.stopovers,            // 생성자 파라미터에 포함
   });
 
   factory PartyDetail.fromJson(Map<String, dynamic> json) {
@@ -29,8 +32,13 @@ class PartyDetail {
 
     final memberList = (json['party_members'] as List<dynamic>?)
         ?.map((m) => PartyMember.fromJson(m as Map<String, dynamic>))
-        .toList() ??
-        [];
+        .toList() ?? [];
+
+    // “stopovers” 배열이 JSON에 내려온다고 가정
+    final stopoverJsonList = (json['stopovers'] as List<dynamic>?) ?? [];
+    final stopovers = stopoverJsonList
+        .map((s) => StopoverResponse.fromJson(s as Map<String, dynamic>))
+        .toList();
 
     return PartyDetail(
       partyId: json['party_id'] as int,
@@ -40,6 +48,7 @@ class PartyDetail {
       maxPerson: json['party_max_people'] as int,
       partyOption: json['party_option'] as String,
       members: memberList,
+      stopovers: stopovers,
     );
   }
 }

--- a/app2_client/lib/models/party_detail_model.dart
+++ b/app2_client/lib/models/party_detail_model.dart
@@ -1,54 +1,64 @@
 // lib/models/party_detail_model.dart
 
-import 'party_member_model.dart';
-import 'stopover_model.dart';
+import 'package:app2_client/models/party_member_model.dart';
 
 class PartyDetail {
   final int partyId;
   final String originAddress;
+  final double originLat;     // 출발지 위도
+  final double originLng;     // 출발지 경도
   final String destAddress;
+  final double destLat;       // 도착지 위도  ← 새로 추가
+  final double destLng;       // 도착지 경도  ← 새로 추가
   final double radius;
   final int maxPerson;
   final String partyOption;
   final List<PartyMember> members;
-  final List<StopoverResponse> stopovers; // ← 추가
 
   PartyDetail({
     required this.partyId,
     required this.originAddress,
+    required this.originLat,
+    required this.originLng,
     required this.destAddress,
+    required this.destLat,
+    required this.destLng,
     required this.radius,
     required this.maxPerson,
     required this.partyOption,
     required this.members,
-    required this.stopovers,            // 생성자 파라미터에 포함
   });
 
   factory PartyDetail.fromJson(Map<String, dynamic> json) {
-    final originAddress =
-        json['party_start']?['location']?['address'] ?? '출발지 정보 없음';
-    final destAddress =
-        json['party_destination']?['location']?['address'] ?? '도착지 정보 없음';
+    // JSON 구조에 따라 “party_start”와 “party_destination” 에서 address/lat/lng 를 꺼냅니다.
+    final startLocation = json['party_start']?['location'] as Map<String, dynamic>? ?? {};
+    final destLocation  = json['party_destination']?['location'] as Map<String, dynamic>? ?? {};
+
+    final originAddress = startLocation['address'] as String? ?? '출발지 정보 없음';
+    final originLat     = (startLocation['lat']    as num?)?.toDouble() ?? 0.0;
+    final originLng     = (startLocation['lng']    as num?)?.toDouble() ?? 0.0;
+
+    final destAddress = destLocation['address'] as String? ?? '도착지 정보 없음';
+    final destLat     = (destLocation['lat']    as num?)?.toDouble() ?? 0.0;
+    final destLng     = (destLocation['lng']    as num?)?.toDouble() ?? 0.0;
 
     final memberList = (json['party_members'] as List<dynamic>?)
         ?.map((m) => PartyMember.fromJson(m as Map<String, dynamic>))
-        .toList() ?? [];
-
-    // “stopovers” 배열이 JSON에 내려온다고 가정
-    final stopoverJsonList = (json['stopovers'] as List<dynamic>?) ?? [];
-    final stopovers = stopoverJsonList
-        .map((s) => StopoverResponse.fromJson(s as Map<String, dynamic>))
-        .toList();
+        .toList() ??
+        [];
 
     return PartyDetail(
       partyId: json['party_id'] as int,
       originAddress: originAddress,
+      originLat: originLat,
+      originLng: originLng,
       destAddress: destAddress,
+      destLat: destLat,       // 추가된 필드
+      destLng: destLng,       // 추가된 필드
       radius: (json['party_radius'] as num).toDouble(),
       maxPerson: json['party_max_people'] as int,
       partyOption: json['party_option'] as String,
       members: memberList,
-      stopovers: stopovers,
     );
   }
 }

--- a/app2_client/lib/models/party_member_model.dart
+++ b/app2_client/lib/models/party_member_model.dart
@@ -1,0 +1,30 @@
+// lib/models/party_member_model.dart
+
+class PartyMember {
+  final int id;
+  final String name;
+  final String email;
+  final String gender;          // e.g. "MALE" or "FEMALE"
+  final String role;            // e.g. "HOST", "MEMBER", "BOOKKEEPER"
+  final String additionalRole;  // 예: HOST 가 BOOKKEEPER 겸하면 "BOOKKEEPER", 아니면 "NONE"
+
+  PartyMember({
+    required this.id,
+    required this.name,
+    required this.email,
+    required this.gender,
+    required this.role,
+    required this.additionalRole,
+  });
+
+  factory PartyMember.fromJson(Map<String, dynamic> json) {
+    return PartyMember(
+      id: json['id'] as int,
+      name: json['name'] as String,
+      email: json['email'] as String,
+      gender: json['gender'] as String,
+      role: json['role'] as String,
+      additionalRole: json['additional_role'] as String? ?? 'NONE',
+    );
+  }
+}

--- a/app2_client/lib/models/stopover_model.dart
+++ b/app2_client/lib/models/stopover_model.dart
@@ -1,25 +1,48 @@
 // lib/models/stopover_model.dart
 
-import 'location_model.dart'; // location_model.dart 에 LocationModel 정의를 가정
+import 'location_model.dart';
+import 'party_member_model.dart';
 
-class StopoverModel {
+/// 서버 응답 구조: { "stopover": { ... }, "partyMembers": [ ... ] }
+class StopoverResponse {
+  final Stopover stopover;
+  final List<PartyMember> partyMembers;
+
+  StopoverResponse({
+    required this.stopover,
+    required this.partyMembers,
+  });
+
+  factory StopoverResponse.fromJson(Map<String, dynamic> json) {
+    final stopoverJson = json['stopover'] as Map<String, dynamic>;
+    final membersJson = (json['partyMembers'] as List<dynamic>?) ?? [];
+
+    return StopoverResponse(
+      stopover: Stopover.fromJson(stopoverJson),
+      partyMembers: membersJson
+          .map((e) => PartyMember.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// 경유지 정보 (id, location, stopoverType)
+class Stopover {
+  final int id;
   final LocationModel location;
-  final String       stopoverType;
+  final String stopoverType; // "START" | "STOPOVER" | "DESTINATION"
 
-  StopoverModel({
+  Stopover({
+    required this.id,
     required this.location,
     required this.stopoverType,
   });
 
-  factory StopoverModel.fromJson(Map<String, dynamic> json) {
-    return StopoverModel(
-      location:     LocationModel.fromJson(json['location'] as Map<String, dynamic>),
+  factory Stopover.fromJson(Map<String, dynamic> json) {
+    return Stopover(
+      id: json['id'] as int,
+      location: LocationModel.fromJson(json['location'] as Map<String, dynamic>),
       stopoverType: json['stopover_type'] as String,
     );
   }
-
-  Map<String, dynamic> toJson() => {
-    'location'      : location.toJson(),
-    'stopover_type' : stopoverType,
-  };
 }

--- a/app2_client/lib/screens/my_party_screen.dart
+++ b/app2_client/lib/screens/my_party_screen.dart
@@ -1,7 +1,12 @@
 // lib/screens/my_party_screen.dart
 
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
+
 import 'package:app2_client/models/party_detail_model.dart';
 import 'package:app2_client/models/stopover_model.dart';
 import 'package:app2_client/models/location_model.dart';
@@ -33,6 +38,13 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
   final TextEditingController _descController = TextEditingController();
   List<JoinRequest> _joinRequests = [];
 
+  // ★ WebViewController 및 로드 여부 플래그
+  WebViewController? _mapController;
+  bool _mapLoaded = false;
+
+  // 로컬에 보관할 StopoverResponse 리스트
+  List<StopoverResponse> _stopoverList = [];
+
   @override
   void initState() {
     super.initState();
@@ -40,6 +52,9 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
     _desc = widget.description ?? '';
     _descController.text = _desc!;
     _subscribeSocket();
+
+    // WebView(파티 지도) 초기화
+    _initMapWebView();
   }
 
   void _subscribeSocket() {
@@ -62,7 +77,13 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
             msg['eventType'] == 'PARTY_UPDATE') {
           final updated = await PartyService.fetchPartyDetailById(
               _party.partyId.toString());
-          setState(() => _party = updated);
+          setState(() {
+            _party = updated;
+            // 만약 서버가 StopoverResponse를 내려준다면 여기서 _stopoverList도 업데이트
+            // 예: _stopoverList = updated.stopovers;
+          });
+          // 지도 마커 업데이트
+          _refreshAllMarkers();
         }
       },
     );
@@ -82,6 +103,77 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
     });
   }
 
+  /// WebViewController를 생성 & kakao_party_map.html 로드
+  Future<void> _initMapWebView() async {
+    // 1) assets 폴더에 kakao_party_map.html 이 반드시 있어야 합니다.
+    final rawHtml = await rootBundle.loadString('assets/kakao_party_map.html');
+
+    final centerLat = _party.destLat;
+    final centerLng = _party.destLng;
+
+    // .env에서 카카오 JS 키를 불러와 치환
+    final kakaoKey = dotenv.env['KAKAO_JS_KEY'] ?? '';
+    final htmlWithParams = rawHtml
+        .replaceAll('{{KAKAO_JS_KEY}}', kakaoKey)
+        .replaceAll('{{CENTER_LAT}}', centerLat.toString())
+        .replaceAll('{{CENTER_LNG}}', centerLng.toString());
+
+    final controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(Colors.transparent)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (_) {
+            // HTML이 완전히 로드된 직후에 true로 바꿔 주고 마커 찍기
+            setState(() {
+              _mapLoaded = true;
+            });
+            _refreshAllMarkers();
+          },
+        ),
+      )
+      ..loadHtmlString(htmlWithParams, baseUrl: 'about:blank');
+
+    setState(() {
+      _mapController = controller;
+    });
+  }
+
+  /// 목적지 + 경유지 전체 마커를 갱신
+  Future<void> _refreshAllMarkers() async {
+    if (!_mapLoaded || _mapController == null) return;
+
+    try {
+      // 1) 기존 마커 모두 제거
+      for (final stop in _stopoverList) {
+        await _mapController!
+            .runJavaScript('removeMarker("${stop.stopover.id}");');
+      }
+      // 목적지(Host dest)는 ID를 “destination” 으로 고정
+      await _mapController!.runJavaScript('removeMarker("destination");');
+
+      // 2) Host 도착지(빨간색) 마커 찍기
+      final destLat = _party.destLat;
+      final destLng = _party.destLng;
+      await _mapController!.runJavaScript(
+        'addMarker("destination", $destLat, $destLng, "목적지", "red");',
+      );
+
+      // 3) 각 경유지(초록색) 마커 찍기
+      for (final stop in _stopoverList) {
+        final id = stop.stopover.id.toString();
+        final lat = stop.stopover.location.lat;
+        final lng = stop.stopover.location.lng;
+        final title = '경유지 #$id';
+        await _mapController!.runJavaScript(
+          'addMarker("$id", $lat, $lng, "$title", "green");',
+        );
+      }
+    } catch (e) {
+      debugPrint('지도 마커 갱신 중 오류: $e');
+    }
+  }
+
   Future<void> _acceptRequest(int requestId) async {
     final token =
         Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
@@ -95,7 +187,7 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
       setState(() {
         _joinRequests.removeWhere((r) => r.requestId == requestId);
       });
-      // 자동으로 브로드캐스트된 MEMBER_JOIN 이벤트가 들어오면 멤버 리스트 갱신됨
+      // MemberJoin 이벤트가 들어오면 자동으로 멤버 리스트 갱신됨
     } catch (e) {
       ScaffoldMessenger.of(context)
           .showSnackBar(SnackBar(content: Text('수락 실패: $e')));
@@ -121,6 +213,7 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
     }
   }
 
+  /// “경유지 추가” 다이얼로그 띄우고, 파티에 경유지 추가 요청 후 로컬 리스트와 마커 갱신, 추가된 경유지 설정 화면으로 이동
   Future<void> _addStopoverDialog() async {
     final token =
         Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
@@ -197,12 +290,14 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
                 final lng = double.tryParse(lngStr);
                 if (lat == null || lng == null) {
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('위도/경도를 올바르게 입력해주세요.')),
+                    const SnackBar(
+                        content: Text('위도/경도를 올바르게 입력해주세요.')),
                   );
                   return;
                 }
 
                 try {
+                  // 백엔드로 경유지 추가 요청
                   final List<StopoverResponse> newList =
                   await PartyService.addStopover(
                     partyId: _party.partyId.toString(),
@@ -211,14 +306,41 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
                         address: address, lat: lat, lng: lng),
                     accessToken: token,
                   );
-                  // (옵션) 로컬 파티 정보를 업데이트하거나, 화면에 경유지 리스트를 띄우고 싶으면
-                  debugPrint('새 경유지 목록: $newList');
+
+                  // 로컬 리스트 갱신 + 마커 다시 찍기
+                  setState(() {
+                    _stopoverList = newList;
+                  });
+
+                  // 새로 추가된 경유지가 있으면 → “하차 지점 설정 화면”으로 바로 이동
+                  if (newList.isNotEmpty) {
+                    final added = newList.firstWhere((e) =>
+                    e.stopover.location.address == address &&
+                        e.partyMembers.any((m) => m.email == email),
+                        orElse: () => newList.first);
+
+                    Navigator.of(context).pop(); // 다이얼로그 닫기
+
+                    // 경유지 설정 화면으로 이동
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => StopoverSettingScreen(
+                          partyId: _party.partyId.toString(),
+                          stopoverData: added,
+                        ),
+                      ),
+                    );
+                    return;
+                  }
                 } catch (e) {
-                  ScaffoldMessenger.of(context)
-                      .showSnackBar(SnackBar(content: Text('경유지 추가 실패: $e')));
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('경유지 추가 실패: $e')),
+                  );
                 }
 
+                // 다이얼로그 닫고, 지도 마커 다시 그리기
                 Navigator.of(context).pop();
+                _refreshAllMarkers();
               },
             ),
           ],
@@ -227,6 +349,7 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
     );
   }
 
+  /// “경유지 수정” 다이얼로그 (MyPartyScreen 내에서도 호출 가능)
   Future<void> _updateStopoverDialog(StopoverResponse existing) async {
     final token =
         Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
@@ -296,20 +419,22 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
                     partyId: _party.partyId.toString(),
                     stopoverId: existing.stopover.id,
                     memberEmail: email.isEmpty ? null : email,
-                    location:
-                    (lat != null && lng != null)
-                        ? LocationModel(
-                        address: address, lat: lat, lng: lng)
+                    location: (lat != null && lng != null)
+                        ? LocationModel(address: address, lat: lat, lng: lng)
                         : null,
                     accessToken: token,
                   );
-                  debugPrint('수정 후 경유지 목록: $updatedList');
+                  setState(() {
+                    _stopoverList = updatedList;
+                  });
                 } catch (e) {
-                  ScaffoldMessenger.of(context)
-                      .showSnackBar(SnackBar(content: Text('경유지 수정 실패: $e')));
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('경유지 수정 실패: $e')),
+                  );
                 }
 
                 Navigator.of(context).pop();
+                _refreshAllMarkers();
               },
             ),
           ],
@@ -338,15 +463,16 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
               child: const Text('확인'),
               onPressed: () async {
                 try {
-                  final updatedMembers = await PartyService.designateBookkeeper(
+                  await PartyService.designateBookkeeper(
                     partyId: _party.partyId.toString(),
                     partyMemberId: member.id.toString(),
                     accessToken: token,
                   );
-                  // (옵션) 로컬 파티 멤버 리스트를 최신화하려면:
                   final refreshed = await PartyService.fetchPartyDetailById(
                       _party.partyId.toString());
-                  setState(() => _party = refreshed);
+                  setState(() {
+                    _party = refreshed;
+                  });
                 } catch (e) {
                   ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(content: Text('정산자 지정 실패: $e')));
@@ -364,178 +490,202 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('내 파티')),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _destinationCard(_party.destAddress),
-            const SizedBox(height: 16),
+      body: Column(
+        children: [
+          // 1) 지도(WebView) 영역
+          SizedBox(
+            height: 240,
+            child: _mapController == null
+                ? const Center(child: CircularProgressIndicator())
+                : WebViewWidget(controller: _mapController!),
+          ),
 
-            // 설명 출력·수정
-            _editingDesc
-                ? Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _descController,
-                    autofocus: true,
-                    decoration: const InputDecoration(
-                      hintText: '설명을 입력하세요',
+          // 2) 나머지 콘텐츠
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 12),
+
+                  // 설명 출력·수정
+                  _editingDesc
+                      ? Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          controller: _descController,
+                          autofocus: true,
+                          decoration: const InputDecoration(
+                            hintText: '설명을 입력하세요',
+                          ),
+                        ),
+                      ),
+                      IconButton(
+                        icon:
+                        const Icon(Icons.check, color: Colors.green),
+                        onPressed: _saveDesc,
+                      ),
+                    ],
+                  )
+                      : Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          _desc!.isEmpty ? '설명을 추가하세요' : _desc!,
+                          style: const TextStyle(fontSize: 16),
+                        ),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.edit, size: 20),
+                        onPressed: () =>
+                            setState(() => _editingDesc = true),
+                      ),
+                    ],
+                  ),
+
+                  const SizedBox(height: 12),
+
+                  // 해시태그
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 4,
+                    children: [
+                      _tag('#${_party.maxPerson}인팟'),
+                      _tag(_party.partyOption == 'MIXED' ? '#혼성' : '#동성만'),
+                    ],
+                  ),
+
+                  const SizedBox(height: 24),
+
+                  // “경유지 추가” 버튼
+                  Center(
+                    child: ElevatedButton.icon(
+                      icon: const Icon(Icons.add_road),
+                      label: const Text('경유지 추가'),
+                      onPressed: _addStopoverDialog,
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 12),
+                      ),
                     ),
                   ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.check, color: Colors.green),
-                  onPressed: _saveDesc,
-                ),
-              ],
-            )
-                : Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    _desc!.isEmpty ? '설명을 추가하세요' : _desc!,
-                    style: const TextStyle(fontSize: 16),
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.edit, size: 20),
-                  onPressed: () => setState(() => _editingDesc = true),
-                ),
-              ],
-            ),
 
-            const SizedBox(height: 12),
+                  const SizedBox(height: 24),
+                  const Divider(),
 
-            // 해시태그
-            Wrap(
-              spacing: 8,
-              runSpacing: 4,
-              children: [
-                _tag('#${_party.maxPerson}인팟'),
-                _tag(_party.partyOption == 'MIXED' ? '#혼성' : '#동성만'),
-              ],
-            ),
+                  // **경유지 리스트** (간단히 ListTile 형태로 표시)
+                  if (_stopoverList.isNotEmpty) ...[
+                    const Text('경유지 목록',
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    ..._stopoverList.map((s) {
+                      return ListTile(
+                        title: Text(s.stopover.location.address),
+                        subtitle: Text(
+                          '하차자: ${s.partyMembers.map((m) => m.name).join(", ")}',
+                        ),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.edit),
+                          onPressed: () {
+                            _updateStopoverDialog(s);
+                          },
+                        ),
+                        onTap: () {
+                          // 해당 경유지 설정 화면으로 이동
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => StopoverSettingScreen(
+                                partyId: _party.partyId.toString(),
+                                stopoverData: s,
+                              ),
+                            ),
+                          );
+                        },
+                      );
+                    }).toList(),
+                    const SizedBox(height: 24),
+                    const Divider(),
+                  ],
 
-            const SizedBox(height: 24),
+                  // **파티원 목록 & 정산자 지정 버튼**
+                  const Text('파티원 목록',
+                      style: TextStyle(fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 8),
+                  ..._party.members.map((m) {
+                    final isBookkeeper =
+                        m.role == 'BOOKKEEPER' || m.additionalRole == 'BOOKKEEPER';
+                    return Card(
+                      child: ListTile(
+                        leading: Icon(
+                          m.gender == 'FEMALE' ? Icons.female : Icons.male,
+                          color: m.gender == 'FEMALE' ? Colors.pink : Colors.blue,
+                        ),
+                        title: Text(m.name),
+                        subtitle: Text(
+                          '${m.email}  |  역할: ${m.role}'
+                              '${m.additionalRole == 'BOOKKEEPER' ? ' (정산자)' : ''}',
+                        ),
+                        trailing: m.role != 'HOST'
+                            ? ElevatedButton(
+                          child: Text(isBookkeeper
+                              ? '정산자 해제'
+                              : '정산자 지정'),
+                          onPressed: () {
+                            _designateBookkeeperDialog(m);
+                          },
+                        )
+                            : const SizedBox.shrink(),
+                      ),
+                    );
+                  }).toList(),
 
-            // “경유지 추가” 버튼
-            Center(
-              child: ElevatedButton.icon(
-                icon: const Icon(Icons.add_road),
-                label: const Text('경유지 추가'),
-                onPressed: _addStopoverDialog,
-                style: ElevatedButton.styleFrom(
-                  padding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                ),
+                  const SizedBox(height: 24),
+
+                  // **참여 요청 리스트**
+                  if (_joinRequests.isNotEmpty) ...[
+                    const Divider(),
+                    const SizedBox(height: 8),
+                    const Text('신규 참여요청',
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 4),
+                    ..._joinRequests.map((req) {
+                      return Card(
+                        color: Colors.amber[50],
+                        child: ListTile(
+                          title: Text(req.userName),
+                          subtitle: Text(req.userEmail),
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                icon: const Icon(Icons.check,
+                                    color: Colors.green),
+                                onPressed: () =>
+                                    _acceptRequest(req.requestId),
+                              ),
+                              IconButton(
+                                icon:
+                                const Icon(Icons.close, color: Colors.red),
+                                onPressed: () =>
+                                    _rejectRequest(req.requestId),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    }).toList(),
+                    const SizedBox(height: 16),
+                  ],
+                ],
               ),
             ),
-
-            const SizedBox(height: 24),
-            const Divider(),
-
-            // **경유지 리스트 (설정된 경유지와 해당 멤버들)**
-            FutureBuilder<List<StopoverResponse>>(
-              future: PartyService
-                  .fetchPartyDetailById(_party.partyId.toString())
-                  .then((_) async {
-                // 서버가 경유지 정보를 함께 내려주지는 않으므로,
-                // “fetch 파티 디테일” 이후 newline((내부 로직이나 별도 엔드포인트 필요시))
-                // 경유지 리스트 API 호출을 추가로 구현해야 합니다.
-                // 하지만 현재 API 명세서 상에는 별도 GET 엔드포인트가 없으므로,
-                // “addStopover” 나 “updateStopover” 호출 후 리턴값에 의존합니다.
-                return <StopoverResponse>[];
-              }),
-              builder: (context, snapshot) {
-                // 이 부분은 “경유지 추가/수정” 후 리턴값을 직접 로컬에 보관해두고,
-                // setState를 통해 레이아웃에 반영하는 방식으로 구현해야 합니다.
-                // 여기서는 예시이므로 비워둡니다.
-                return const SizedBox.shrink();
-              },
-            ),
-
-            const SizedBox(height: 24),
-
-            // **파티원 리스트 & 정산자 지정 버튼**
-            const Text('파티원 목록', style: TextStyle(fontWeight: FontWeight.bold)),
-            ..._party.members.map((m) {
-              final isBookkeeper = m.role == 'BOOKKEEPER' ||
-                  m.additionalRole == 'BOOKKEEPER';
-              return Card(
-                child: ListTile(
-                  leading: Icon(
-                    m.gender == 'FEMALE' ? Icons.female : Icons.male,
-                    color: m.gender == 'FEMALE' ? Colors.pink : Colors.blue,
-                  ),
-                  title: Text(m.name),
-                  subtitle: Text('${m.email}  |  역할: ${m.role}'
-                      '${m.additionalRole == 'BOOKKEEPER' ? ' (정산자)' : ''}'),
-                  trailing: m.role != 'HOST'
-                      ? ElevatedButton(
-                    child: Text(isBookkeeper ? '정산자 해제' : '정산자 지정'),
-                    onPressed: () {
-                      _designateBookkeeperDialog(m);
-                    },
-                  )
-                      : const SizedBox.shrink(),
-                ),
-              );
-            }).toList(),
-
-            const SizedBox(height: 24),
-
-            // **참여 요청 리스트 (생략: JoinRequest UI)**
-            if (_joinRequests.isNotEmpty) ...[
-              const Divider(),
-              const Text('신규 참여요청', style: TextStyle(fontWeight: FontWeight.bold)),
-              ..._joinRequests.map((req) {
-                return Card(
-                  color: Colors.amber[50],
-                  child: ListTile(
-                    title: Text(req.userName),
-                    subtitle: Text(req.userEmail),
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        IconButton(
-                          icon: const Icon(Icons.check, color: Colors.green),
-                          onPressed: () => _acceptRequest(req.requestId),
-                        ),
-                        IconButton(
-                          icon: const Icon(Icons.close, color: Colors.red),
-                          onPressed: () => _rejectRequest(req.requestId),
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              }).toList(),
-            ],
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
-
-  Widget _destinationCard(String address) => Container(
-    decoration: BoxDecoration(
-      color: Colors.grey[200],
-      borderRadius: BorderRadius.circular(12),
-    ),
-    padding: const EdgeInsets.all(16),
-    child: Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text('목적지', style: TextStyle(fontWeight: FontWeight.bold)),
-        const SizedBox(height: 4),
-        Text(address),
-        const SizedBox(height: 12),
-        const Center(child: Icon(Icons.location_on, size: 48, color: Colors.amber)),
-      ],
-    ),
-  );
 
   Widget _tag(String label) => Container(
     padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),

--- a/app2_client/lib/screens/my_party_screen.dart
+++ b/app2_client/lib/screens/my_party_screen.dart
@@ -1,51 +1,68 @@
+// lib/screens/my_party_screen.dart
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:app2_client/models/party_detail_model.dart';
+import 'package:app2_client/models/stopover_model.dart';
+import 'package:app2_client/models/location_model.dart';
+import 'package:app2_client/models/party_member_model.dart';
 import 'package:app2_client/providers/auth_provider.dart';
 import 'package:app2_client/services/socket_service.dart';
 import 'package:app2_client/services/party_service.dart';
+import 'package:app2_client/models/join_request_model.dart';
+import 'package:app2_client/screens/stopover_setting_screen.dart';
 
 class MyPartyScreen extends StatefulWidget {
   final PartyDetail party;
   final String? description;
 
   const MyPartyScreen({
-    super.key,
+    Key? key,
     required this.party,
     this.description,
-  });
+  }) : super(key: key);
 
   @override
   State<MyPartyScreen> createState() => _MyPartyScreenState();
 }
 
 class _MyPartyScreenState extends State<MyPartyScreen> {
-  late PartyDetail party;
+  late PartyDetail _party;
   String? _desc;
   bool _editingDesc = false;
-  final _descController = TextEditingController();
-  List<dynamic> joinRequests = []; // 생략: JoinRequest 모델로 변환 가능
+  final TextEditingController _descController = TextEditingController();
+  List<JoinRequest> _joinRequests = [];
 
   @override
   void initState() {
     super.initState();
-    party = widget.party;
+    _party = widget.party;
     _desc = widget.description ?? '';
     _descController.text = _desc!;
     _subscribeSocket();
   }
 
   void _subscribeSocket() {
-    final token = Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
+    final token =
+        Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
     if (token == null) return;
     SocketService.connect(token);
+
     SocketService.subscribe(
-      topic: "/sub/party/${party.partyId}",
+      topic: "/sub/party/${_party.partyId}",
       onMessage: (msg) async {
-        // 생략: JOIN_REQUEST 처리
-        if (msg['eventType'] == 'MEMBER_JOIN' || msg['eventType'] == 'PARTY_UPDATE') {
-          final updated = await PartyService.fetchPartyDetailById(party.partyId.toString());
-          setState(() => party = updated);
+        // 참여 요청 수신
+        if (msg['type'] == 'JOIN_REQUEST') {
+          setState(() {
+            _joinRequests.add(JoinRequest.fromJson(msg));
+          });
+        }
+        // 멤버 리스트 갱신 or 파티 업데이트 메시지 수신
+        else if (msg['eventType'] == 'MEMBER_JOIN' ||
+            msg['eventType'] == 'PARTY_UPDATE') {
+          final updated = await PartyService.fetchPartyDetailById(
+              _party.partyId.toString());
+          setState(() => _party = updated);
         }
       },
     );
@@ -65,6 +82,284 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
     });
   }
 
+  Future<void> _acceptRequest(int requestId) async {
+    final token =
+        Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
+    if (token == null) return;
+    try {
+      await PartyService.acceptJoinRequest(
+        partyId: _party.partyId.toString(),
+        requestId: requestId,
+        accessToken: token,
+      );
+      setState(() {
+        _joinRequests.removeWhere((r) => r.requestId == requestId);
+      });
+      // 자동으로 브로드캐스트된 MEMBER_JOIN 이벤트가 들어오면 멤버 리스트 갱신됨
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('수락 실패: $e')));
+    }
+  }
+
+  Future<void> _rejectRequest(int requestId) async {
+    final token =
+        Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
+    if (token == null) return;
+    try {
+      await PartyService.rejectJoinRequest(
+        partyId: _party.partyId.toString(),
+        requestId: requestId,
+        accessToken: token,
+      );
+      setState(() {
+        _joinRequests.removeWhere((r) => r.requestId == requestId);
+      });
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('거절 실패: $e')));
+    }
+  }
+
+  Future<void> _addStopoverDialog() async {
+    final token =
+        Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
+    if (token == null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('로그인이 필요합니다.')));
+      return;
+    }
+
+    String email = '';
+    String address = '';
+    String latStr = '';
+    String lngStr = '';
+
+    final _emailController = TextEditingController();
+    final _addressController = TextEditingController();
+    final _latController = TextEditingController();
+    final _lngController = TextEditingController();
+
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('경유지 추가'),
+          content: SingleChildScrollView(
+            child: Column(
+              children: [
+                TextField(
+                  controller: _emailController,
+                  decoration:
+                  const InputDecoration(labelText: '내릴 유저 이메일'),
+                ),
+                TextField(
+                  controller: _addressController,
+                  decoration: const InputDecoration(labelText: '주소'),
+                ),
+                TextField(
+                  controller: _latController,
+                  decoration: const InputDecoration(labelText: '위도'),
+                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                ),
+                TextField(
+                  controller: _lngController,
+                  decoration: const InputDecoration(labelText: '경도'),
+                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              child: const Text('취소'),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            ElevatedButton(
+              child: const Text('추가'),
+              onPressed: () async {
+                email = _emailController.text.trim();
+                address = _addressController.text.trim();
+                latStr = _latController.text.trim();
+                lngStr = _lngController.text.trim();
+
+                if (email.isEmpty ||
+                    address.isEmpty ||
+                    latStr.isEmpty ||
+                    lngStr.isEmpty) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('모든 항목을 입력해주세요.')),
+                  );
+                  return;
+                }
+
+                final lat = double.tryParse(latStr);
+                final lng = double.tryParse(lngStr);
+                if (lat == null || lng == null) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('위도/경도를 올바르게 입력해주세요.')),
+                  );
+                  return;
+                }
+
+                try {
+                  final List<StopoverResponse> newList =
+                  await PartyService.addStopover(
+                    partyId: _party.partyId.toString(),
+                    memberEmail: email,
+                    location: LocationModel(
+                        address: address, lat: lat, lng: lng),
+                    accessToken: token,
+                  );
+                  // (옵션) 로컬 파티 정보를 업데이트하거나, 화면에 경유지 리스트를 띄우고 싶으면
+                  debugPrint('새 경유지 목록: $newList');
+                } catch (e) {
+                  ScaffoldMessenger.of(context)
+                      .showSnackBar(SnackBar(content: Text('경유지 추가 실패: $e')));
+                }
+
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _updateStopoverDialog(StopoverResponse existing) async {
+    final token =
+        Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
+    if (token == null) return;
+
+    String email = existing.partyMembers.isNotEmpty
+        ? existing.partyMembers.first.email
+        : '';
+    String address = existing.stopover.location.address;
+    String latStr = existing.stopover.location.lat.toString();
+    String lngStr = existing.stopover.location.lng.toString();
+
+    final _emailController = TextEditingController(text: email);
+    final _addressController = TextEditingController(text: address);
+    final _latController = TextEditingController(text: latStr);
+    final _lngController = TextEditingController(text: lngStr);
+
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('경유지 수정'),
+          content: SingleChildScrollView(
+            child: Column(
+              children: [
+                TextField(
+                  controller: _emailController,
+                  decoration:
+                  const InputDecoration(labelText: '내릴 유저 이메일'),
+                ),
+                TextField(
+                  controller: _addressController,
+                  decoration: const InputDecoration(labelText: '주소'),
+                ),
+                TextField(
+                  controller: _latController,
+                  decoration: const InputDecoration(labelText: '위도'),
+                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                ),
+                TextField(
+                  controller: _lngController,
+                  decoration: const InputDecoration(labelText: '경도'),
+                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              child: const Text('취소'),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            ElevatedButton(
+              child: const Text('수정'),
+              onPressed: () async {
+                email = _emailController.text.trim();
+                address = _addressController.text.trim();
+                latStr = _latController.text.trim();
+                lngStr = _lngController.text.trim();
+
+                final double? lat = double.tryParse(latStr);
+                final double? lng = double.tryParse(lngStr);
+
+                try {
+                  final List<StopoverResponse> updatedList =
+                  await PartyService.updateStopover(
+                    partyId: _party.partyId.toString(),
+                    stopoverId: existing.stopover.id,
+                    memberEmail: email.isEmpty ? null : email,
+                    location:
+                    (lat != null && lng != null)
+                        ? LocationModel(
+                        address: address, lat: lat, lng: lng)
+                        : null,
+                    accessToken: token,
+                  );
+                  debugPrint('수정 후 경유지 목록: $updatedList');
+                } catch (e) {
+                  ScaffoldMessenger.of(context)
+                      .showSnackBar(SnackBar(content: Text('경유지 수정 실패: $e')));
+                }
+
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _designateBookkeeperDialog(PartyMember member) async {
+    final token =
+        Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
+    if (token == null) return;
+
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('정산자 지정 확인'),
+          content: Text('${member.name}님을 정산자로 지정하시겠습니까?'),
+          actions: [
+            TextButton(
+              child: const Text('취소'),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            ElevatedButton(
+              child: const Text('확인'),
+              onPressed: () async {
+                try {
+                  final updatedMembers = await PartyService.designateBookkeeper(
+                    partyId: _party.partyId.toString(),
+                    partyMemberId: member.id.toString(),
+                    accessToken: token,
+                  );
+                  // (옵션) 로컬 파티 멤버 리스트를 최신화하려면:
+                  final refreshed = await PartyService.fetchPartyDetailById(
+                      _party.partyId.toString());
+                  setState(() => _party = refreshed);
+                } catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('정산자 지정 실패: $e')));
+                }
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -74,10 +369,10 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _destinationCard(party.destAddress),
+            _destinationCard(_party.destAddress),
             const SizedBox(height: 16),
 
-            // 설명 출력 및 수정
+            // 설명 출력·수정
             _editingDesc
                 ? Row(
               children: [
@@ -112,16 +407,112 @@ class _MyPartyScreenState extends State<MyPartyScreen> {
             ),
 
             const SizedBox(height: 12),
+
+            // 해시태그
             Wrap(
               spacing: 8,
               runSpacing: 4,
               children: [
-                _tag('#${party.maxPerson}인팟'),
-                _tag(party.partyOption == 'MIXED' ? '#혼성' : '#동성만'),
+                _tag('#${_party.maxPerson}인팟'),
+                _tag(_party.partyOption == 'MIXED' ? '#혼성' : '#동성만'),
               ],
             ),
 
-            // 이하 기존 파티원 리스트, 참여 요청 처리 UI 등...
+            const SizedBox(height: 24),
+
+            // “경유지 추가” 버튼
+            Center(
+              child: ElevatedButton.icon(
+                icon: const Icon(Icons.add_road),
+                label: const Text('경유지 추가'),
+                onPressed: _addStopoverDialog,
+                style: ElevatedButton.styleFrom(
+                  padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 24),
+            const Divider(),
+
+            // **경유지 리스트 (설정된 경유지와 해당 멤버들)**
+            FutureBuilder<List<StopoverResponse>>(
+              future: PartyService
+                  .fetchPartyDetailById(_party.partyId.toString())
+                  .then((_) async {
+                // 서버가 경유지 정보를 함께 내려주지는 않으므로,
+                // “fetch 파티 디테일” 이후 newline((내부 로직이나 별도 엔드포인트 필요시))
+                // 경유지 리스트 API 호출을 추가로 구현해야 합니다.
+                // 하지만 현재 API 명세서 상에는 별도 GET 엔드포인트가 없으므로,
+                // “addStopover” 나 “updateStopover” 호출 후 리턴값에 의존합니다.
+                return <StopoverResponse>[];
+              }),
+              builder: (context, snapshot) {
+                // 이 부분은 “경유지 추가/수정” 후 리턴값을 직접 로컬에 보관해두고,
+                // setState를 통해 레이아웃에 반영하는 방식으로 구현해야 합니다.
+                // 여기서는 예시이므로 비워둡니다.
+                return const SizedBox.shrink();
+              },
+            ),
+
+            const SizedBox(height: 24),
+
+            // **파티원 리스트 & 정산자 지정 버튼**
+            const Text('파티원 목록', style: TextStyle(fontWeight: FontWeight.bold)),
+            ..._party.members.map((m) {
+              final isBookkeeper = m.role == 'BOOKKEEPER' ||
+                  m.additionalRole == 'BOOKKEEPER';
+              return Card(
+                child: ListTile(
+                  leading: Icon(
+                    m.gender == 'FEMALE' ? Icons.female : Icons.male,
+                    color: m.gender == 'FEMALE' ? Colors.pink : Colors.blue,
+                  ),
+                  title: Text(m.name),
+                  subtitle: Text('${m.email}  |  역할: ${m.role}'
+                      '${m.additionalRole == 'BOOKKEEPER' ? ' (정산자)' : ''}'),
+                  trailing: m.role != 'HOST'
+                      ? ElevatedButton(
+                    child: Text(isBookkeeper ? '정산자 해제' : '정산자 지정'),
+                    onPressed: () {
+                      _designateBookkeeperDialog(m);
+                    },
+                  )
+                      : const SizedBox.shrink(),
+                ),
+              );
+            }).toList(),
+
+            const SizedBox(height: 24),
+
+            // **참여 요청 리스트 (생략: JoinRequest UI)**
+            if (_joinRequests.isNotEmpty) ...[
+              const Divider(),
+              const Text('신규 참여요청', style: TextStyle(fontWeight: FontWeight.bold)),
+              ..._joinRequests.map((req) {
+                return Card(
+                  color: Colors.amber[50],
+                  child: ListTile(
+                    title: Text(req.userName),
+                    subtitle: Text(req.userEmail),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.check, color: Colors.green),
+                          onPressed: () => _acceptRequest(req.requestId),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.close, color: Colors.red),
+                          onPressed: () => _rejectRequest(req.requestId),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              }).toList(),
+            ],
           ],
         ),
       ),

--- a/app2_client/lib/screens/stopover_setting_screen.dart
+++ b/app2_client/lib/screens/stopover_setting_screen.dart
@@ -56,7 +56,7 @@ class _StopoverSettingScreenState extends State<StopoverSettingScreen> {
         ),
         accessToken: token,
       );
-      // (옵션) 화면에 새로 업데이트된 데이터를 반영하려면:
+      // 화면에 반영하려면 업데이트된 리스트 중 해당 아이템만 찾아서 덮어쓰기
       final updated = updatedList.firstWhere((e) =>
       e.stopover.id == _stopover.stopover.id);
       setState(() => _stopover = updated);
@@ -179,7 +179,8 @@ class _StopoverSettingScreenState extends State<StopoverSettingScreen> {
           children: [
             Text(
               '경유지: ${_stopover.stopover.location.address}',
-              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+              style:
+              const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
             const SizedBox(height: 12),
             const Text('내릴 멤버 목록', style: TextStyle(fontWeight: FontWeight.bold)),

--- a/app2_client/lib/screens/stopover_setting_screen.dart
+++ b/app2_client/lib/screens/stopover_setting_screen.dart
@@ -1,0 +1,219 @@
+// lib/screens/stopover_setting_screen.dart
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:app2_client/models/stopover_model.dart';
+import 'package:app2_client/models/location_model.dart';
+import 'package:app2_client/providers/auth_provider.dart';
+import 'package:app2_client/services/party_service.dart';
+
+import '../models/party_member_model.dart';
+
+class StopoverSettingScreen extends StatefulWidget {
+  final String partyId;
+  final StopoverResponse stopoverData;
+
+  const StopoverSettingScreen({
+    Key? key,
+    required this.partyId,
+    required this.stopoverData,
+  }) : super(key: key);
+
+  @override
+  State<StopoverSettingScreen> createState() => _StopoverSettingScreenState();
+}
+
+class _StopoverSettingScreenState extends State<StopoverSettingScreen> {
+  late StopoverResponse _stopover;
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _stopover = widget.stopoverData;
+  }
+
+  Future<void> _updateMemberDropoff({
+    required String memberEmail,
+    required String address,
+    required double lat,
+    required double lng,
+  }) async {
+    final token =
+        Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
+    if (token == null) return;
+
+    try {
+      setState(() => _loading = true);
+      final updatedList = await PartyService.updateStopover(
+        partyId: widget.partyId,
+        stopoverId: _stopover.stopover.id,
+        memberEmail: memberEmail,
+        location: LocationModel(
+          address: address,
+          lat: lat,
+          lng: lng,
+        ),
+        accessToken: token,
+      );
+      // (옵션) 화면에 새로 업데이트된 데이터를 반영하려면:
+      final updated = updatedList.firstWhere((e) =>
+      e.stopover.id == _stopover.stopover.id);
+      setState(() => _stopover = updated);
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('수정 실패: $e')));
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _removeMemberFromStopover(String memberEmail) async {
+    final token =
+        Provider.of<AuthProvider>(context, listen: false).tokens?.accessToken;
+    if (token == null) return;
+
+    try {
+      setState(() => _loading = true);
+      // PATCH API 호출: “member_email”만 보내면 해당 멤버가 경유지에서 내려집니다.
+      final updatedList = await PartyService.updateStopover(
+        partyId: widget.partyId,
+        stopoverId: _stopover.stopover.id,
+        memberEmail: memberEmail,
+        location: null,
+        accessToken: token,
+      );
+      final updated = updatedList.firstWhere((e) =>
+      e.stopover.id == _stopover.stopover.id);
+      setState(() => _stopover = updated);
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('멤버 제거 실패: $e')));
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _showEditDialog(PartyMember member) async {
+    String email = member.email;
+    String address = _stopover.stopover.location.address;
+    String latStr = _stopover.stopover.location.lat.toString();
+    String lngStr = _stopover.stopover.location.lng.toString();
+
+    final _addressController = TextEditingController(text: address);
+    final _latController = TextEditingController(text: latStr);
+    final _lngController = TextEditingController(text: lngStr);
+
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('${member.name}님 하차 지점 수정'),
+          content: SingleChildScrollView(
+            child: Column(
+              children: [
+                TextField(
+                  controller: _addressController,
+                  decoration: const InputDecoration(labelText: '주소'),
+                ),
+                TextField(
+                  controller: _latController,
+                  decoration: const InputDecoration(labelText: '위도'),
+                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                ),
+                TextField(
+                  controller: _lngController,
+                  decoration: const InputDecoration(labelText: '경도'),
+                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              child: const Text('취소'),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            ElevatedButton(
+              child: const Text('저장'),
+              onPressed: () async {
+                final updatedAddress = _addressController.text.trim();
+                final updatedLat = double.tryParse(_latController.text.trim());
+                final updatedLng = double.tryParse(_lngController.text.trim());
+                if (updatedAddress.isEmpty ||
+                    updatedLat == null ||
+                    updatedLng == null) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('모든 필드를 올바르게 입력해주세요.')),
+                  );
+                  return;
+                }
+                Navigator.of(context).pop();
+                await _updateMemberDropoff(
+                  memberEmail: email,
+                  address: updatedAddress,
+                  lat: updatedLat,
+                  lng: updatedLng,
+                );
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final members = _stopover.partyMembers;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('하차 지점 설정'),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '경유지: ${_stopover.stopover.location.address}',
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+            const SizedBox(height: 12),
+            const Text('내릴 멤버 목록', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            ...members.map((m) {
+              return Card(
+                child: ListTile(
+                  title: Text(m.name),
+                  subtitle: Text('${m.email}  |  역할: ${m.role}'),
+                  trailing: PopupMenuButton<String>(
+                    onSelected: (value) async {
+                      if (value == '수정') {
+                        await _showEditDialog(m);
+                      } else if (value == '제거') {
+                        await _removeMemberFromStopover(m.email);
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      const PopupMenuItem(
+                        value: '수정',
+                        child: Text('하차 위치 수정'),
+                      ),
+                      const PopupMenuItem(
+                        value: '제거',
+                        child: Text('경유지에서 제거'),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }).toList(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app2_client/lib/services/party_service.dart
+++ b/app2_client/lib/services/party_service.dart
@@ -127,7 +127,7 @@ class PartyService {
     return null;
   }
 
-  /// 파티 상세정보 조회
+  /// 파티 상세조회
   static Future<PartyDetail> fetchPartyDetailById(String partyId) async {
     final url = "${ApiConstants.partyEndpoint}/$partyId";
     final response = await DioClient.dio.get(url);

--- a/app2_client/pubspec.yaml
+++ b/app2_client/pubspec.yaml
@@ -86,6 +86,7 @@ flutter:
   uses-material-design: true
 
   assets:
+    - assets/kakao_party_map.html
     - assets/app_wide_logo.png
     - assets/kakao_map.html
     - .env


### PR DESCRIPTION
- PartyService에 addStopover, updateStopover, designateBookkeeper 메서드 구현 • POST /api/party/{id} : 경유지 추가 • PATCH /api/party/{id} : 경유지 수정 • PATCH /api/party/{partyId}/member/{partyMemberId}/bookkeeper : 정산자 지정

- MyPartyScreen 수정 (호스트 전용) • 경유지 추가 버튼 및 다이얼로그 (_addStopoverDialog) 추가 • 경유지 수정 다이얼로그 (_updateStopoverDialog) 추가 • 정산자 지정 다이얼로그 (_designateBookkeeperDialog) 추가 • 실시간 WebSocket 구독에 경유지/파티 업데이트 로직 유지

- StopoverSettingScreen 신규 생성 • 특정 경유지 클릭 시 진입하여 하차 멤버별 위치 수정 및 제거 로직 구현

- 모델 추가 • stopover_model.dart : StopoverResponse, Stopover • party_member_model.dart : PartyMember (정산자 역할 포함) • location_model.dart : LocationModel

- PartyDetail, PartyMember 등 기존 모델 데이터 클래스와 호환되도록 json 파싱 유지