### PR TITLE
[fix] 파티 생성/조회/참여 전면수정 및 지도 마커 UX 개선

### DIFF
--- a/app2_client/assets/kakao_party_map.html
+++ b/app2_client/assets/kakao_party_map.html
@@ -15,8 +15,9 @@
 <script>
     let map;
     // Flutter 쪽에서 중심 좌표(LAT, LNG)를 치환해서 넣어 줘야 합니다.
-    let centerLat = {{CENTER_LAT}};
-    let centerLng = {{CENTER_LNG}};
+    let centerLat = parseFloat('{{CENTER_LAT}}');
+    let centerLng = parseFloat('{{CENTER_LNG}}');
+    console.log('지도 중심 좌표:', centerLat, centerLng);
 
     // 마커들을 관리하기 위한 객체
     const markers = {};
@@ -33,6 +34,10 @@
     // Flutter에서 호출: 마커 추가
     // id: String, lat: Number, lng: Number, title: String, color: "blue"/"red"/"green" 등
     window.addMarker = function (id, lat, lng, title, color) {
+      if (!map) {
+        alert('지도(map)가 아직 초기화되지 않았습니다!');
+        return;
+      }
       // 이미 같은 id의 마커가 있으면 제거
       if (markers[id]) {
         markers[id].setMap(null);
@@ -53,8 +58,8 @@
         default:
           imageUrl = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_blue.png';
       }
-      const imageSize = new kakao.maps.Size(36, 54);
-      const imageOption = { offset: new kakao.maps.Point(18, 54) };
+      const imageSize = new kakao.maps.Size(64, 96);
+      const imageOption = { offset: new kakao.maps.Point(32, 96) };
 
       const markerImage = new kakao.maps.MarkerImage(imageUrl, imageSize, imageOption);
       const marker = new kakao.maps.Marker({
@@ -64,15 +69,15 @@
         image: markerImage
       });
 
-      // 마커 클릭 시 Flutter로 메시지 전달(필요할 때만 사용)
+      // 마커 클릭 시 Flutter로 메시지 전달(webview_flutter용)
       kakao.maps.event.addListener(marker, 'click', function () {
-        // 예: Flutter 쪽에서 `onMarkerClick` 핸들러를 정의해 두면, 호출해 줄 수 있습니다.
-        if (window.flutter_inappwebview) {
-          window.flutter_inappwebview.callHandler('onMarkerClick', id);
+        if (window.MarkerClick) {
+          window.MarkerClick.postMessage(JSON.stringify({ id: id }));
         }
       });
 
       markers[id] = marker;
+      console.log('마커 추가:', id, lat, lng, title, color);
     };
 
     // Flutter에서 호출: 특정 id의 마커를 제거

--- a/app2_client/assets/kakao_party_map.html
+++ b/app2_client/assets/kakao_party_map.html
@@ -45,21 +45,11 @@
       }
 
       const position = new kakao.maps.LatLng(lat, lng);
-      // 컬러별 이미지 URL 설정 (기본 제공 마커 이미지를 대체)
-      let imageUrl;
-      switch (color) {
-        case 'red':
-          imageUrl = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_red.png';
-          break;
-        case 'green':
-          imageUrl = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_green.png';
-          break;
-        case 'blue':
-        default:
-          imageUrl = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_blue.png';
-      }
-      const imageSize = new kakao.maps.Size(64, 96);
-      const imageOption = { offset: new kakao.maps.Point(32, 96) };
+      
+      // 카카오 기본 빨간 마커로 통일
+      const imageUrl = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_red.png';
+      const imageSize = new kakao.maps.Size(64, 69);
+      const imageOption = { offset: new kakao.maps.Point(27, 69) };
 
       const markerImage = new kakao.maps.MarkerImage(imageUrl, imageSize, imageOption);
       const marker = new kakao.maps.Marker({

--- a/app2_client/lib/app.dart
+++ b/app2_client/lib/app.dart
@@ -2,33 +2,27 @@ import 'package:app2_client/main.dart';
 import 'package:app2_client/screens/login_screen.dart';
 import 'package:app2_client/screens/root_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-
-import 'providers/auth_provider.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => AuthProvider(),
-      child: MaterialApp(
-        title: '같이타요',
-        debugShowCheckedModeBanner: false,
-        navigatorKey: navigatorKey,
-        theme: ThemeData(
-          fontFamily: 'Pretendard',
-          colorScheme: ColorScheme.fromSeed(seedColor: Color(0xFF003366)),
-          outlinedButtonTheme: OutlinedButtonThemeData(
-            style: OutlinedButton.styleFrom(
-              side: const BorderSide(color: Color(0xFF003366))
-            )
-          ),
-          useMaterial3: true,
+    return MaterialApp(
+      title: '같이타요',
+      debugShowCheckedModeBanner: false,
+      navigatorKey: navigatorKey,
+      theme: ThemeData(
+        fontFamily: 'Pretendard',
+        colorScheme: ColorScheme.fromSeed(seedColor: Color(0xFF003366)),
+        outlinedButtonTheme: OutlinedButtonThemeData(
+          style: OutlinedButton.styleFrom(
+            side: const BorderSide(color: Color(0xFF003366))
+          )
         ),
-        home: RootScreen(),
+        useMaterial3: true,
       ),
+      home: RootScreen(),
     );
   }
 }

--- a/app2_client/lib/main.dart
+++ b/app2_client/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:firebase_core/firebase_core.dart'; // Firebase 추가 시 사용
 import 'package:app2_client/providers/auth_provider.dart';
 import 'package:app2_client/app.dart';
+import 'package:overlay_support/overlay_support.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
@@ -17,10 +18,15 @@ Future<void> main() async {
     await Firebase.initializeApp();
   }
 
+  final authProvider = AuthProvider();
+  await authProvider.initTokens();
+
   runApp(
-    ChangeNotifierProvider(
-      create: (_) => AuthProvider(),
-      child: const MyApp(),
+    OverlaySupport.global(
+      child: ChangeNotifierProvider.value(
+        value: authProvider,
+        child: const MyApp(),
+      ),
     ),
   );
 }

--- a/app2_client/lib/models/party_model.dart
+++ b/app2_client/lib/models/party_model.dart
@@ -26,17 +26,26 @@ class PartyModel {
   });
 
   factory PartyModel.fromJson(Map<String, dynamic> json) {
+    // party_members에서 첫 번째 멤버의 이름을 creatorName으로 사용
+    final members = json['party_members'] as List?;
+    final creatorName = (members != null && members.isNotEmpty)
+        ? (members[0]['name'] as String? ?? '')
+        : '';
+    // 출발지/도착지 정보 추출
+    final stopovers = json['party_stopovers'] as List? ?? [];
+    final start = stopovers.firstWhere((e) => e['stopover_type'] == 'START', orElse: () => null);
+    final dest = stopovers.firstWhere((e) => e['stopover_type'] == 'DESTINATION', orElse: () => null);
     return PartyModel(
-      id: json['id'] as String,
-      creatorName: json['creatorName'] as String,
-      createdAt: DateTime.parse(json['createdAt'] as String),
-      remainingSeats: json['remainingSeats'] as int,
-      originAddress: json['originAddress'] as String,
-      destAddress: json['destAddress'] as String,
-      originLat: (json['originLat'] as num).toDouble(),
-      originLng: (json['originLng'] as num).toDouble(),
-      destLat: (json['destLat'] as num).toDouble(),
-      destLng: (json['destLng'] as num).toDouble(),
+      id: json['party_id'].toString(),
+      creatorName: creatorName,
+      createdAt: DateTime.now(), // 서버에서 createdAt이 없으므로 임시로 현재 시간
+      remainingSeats: (json['party_max_people'] as int) - (json['party_current_people'] as int),
+      originAddress: start != null ? start['location']['address'] as String : '',
+      destAddress: dest != null ? dest['location']['address'] as String : '',
+      originLat: start != null ? (start['location']['lat'] as num).toDouble() : 0.0,
+      originLng: start != null ? (start['location']['lng'] as num).toDouble() : 0.0,
+      destLat: dest != null ? (dest['location']['lat'] as num).toDouble() : 0.0,
+      destLng: dest != null ? (dest['location']['lng'] as num).toDouble() : 0.0,
     );
   }
 

--- a/app2_client/lib/providers/auth_provider.dart
+++ b/app2_client/lib/providers/auth_provider.dart
@@ -1,6 +1,7 @@
 // lib/providers/auth_provider.dart
 import 'package:app2_client/models/user_model.dart';
 import 'package:app2_client/services/auth_service.dart';
+import 'package:app2_client/services/secure_storage_service.dart';
 import 'package:flutter/material.dart';
 
 class AuthProvider extends ChangeNotifier {
@@ -67,5 +68,16 @@ class AuthProvider extends ChangeNotifier {
     }
 
     return false;
+  }
+
+  /// 앱 시작 시 secure storage에서 토큰을 불러와 Provider에 세팅
+  Future<void> initTokens() async {
+    final storage = SecureStorageService();
+    final accessToken = await storage.getAccessToken();
+    final refreshToken = await storage.getRefreshToken();
+    if (accessToken != null && accessToken.isNotEmpty && refreshToken != null && refreshToken.isNotEmpty) {
+      _tokens = AuthResponse(statusCode: 200, accessToken: accessToken, refreshToken: refreshToken);
+      notifyListeners();
+    }
   }
 }

--- a/app2_client/lib/providers/auth_provider.dart
+++ b/app2_client/lib/providers/auth_provider.dart
@@ -80,4 +80,12 @@ class AuthProvider extends ChangeNotifier {
       notifyListeners();
     }
   }
+
+  /// 로그아웃: 토큰/유저 상태 초기화 및 AuthService.logout 호출
+  Future<void> logout() async {
+    await _authService.logout();
+    _tokens = null;
+    _user = null;
+    notifyListeners();
+  }
 }

--- a/app2_client/lib/screens/my_page_content.dart
+++ b/app2_client/lib/screens/my_page_content.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:app2_client/services/profile_service.dart';
+import 'package:app2_client/providers/auth_provider.dart';
 
 class MyPage extends StatefulWidget {
   const MyPage({super.key});
@@ -190,6 +192,23 @@ class _MyPageState extends State<MyPage> {
                   ],
                 ),
               ],
+            ),
+          ),
+          // 로그아웃 버튼 추가
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.red,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+              ),
+              onPressed: () {
+                // 로그아웃 실행
+                context.read<AuthProvider>().logout();
+              },
+              child: const Text('로그아웃', style: TextStyle(fontSize: 16, color: Colors.white)),
             ),
           ),
         ],

--- a/app2_client/lib/screens/my_page_popup.dart
+++ b/app2_client/lib/screens/my_page_popup.dart
@@ -12,78 +12,58 @@ class MyPagePopup {
       builder: (BuildContext context) {
         return Material(
           color: Colors.transparent,
-          child: Stack(
-            children: [
-              Align(
-                alignment: Alignment.topRight,
-                child: Padding(
-                  padding: const EdgeInsets.only(top: 90, right: 20),
-                  child: Stack(
-                    children: [
-                      Container(
-                        width: 280,
-                        padding: const EdgeInsets.all(8),
-                        decoration: BoxDecoration(
-                          color: Colors.white,
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        child: MyPage(),
+          child: Center(
+            child: Container(
+              width: 320,
+              constraints: const BoxConstraints(
+                maxHeight: 700,
+              ),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Align(
+                      alignment: Alignment.topRight,
+                      child: GestureDetector(
+                        onTap: () => Navigator.of(context).pop(),
+                        child: const Icon(Icons.close, size: 20, color: Colors.black54),
                       ),
-                      Positioned(
-                        top: 20,
-                        right: 15,
-                        child: GestureDetector(
-                          onTap: () => Navigator.of(context).pop(),
-                          child: const Icon(Icons.close, size: 20, color: Colors.black54),
+                    ),
+                    const SizedBox(height: 8),
+                    MyPage(),
+                    const SizedBox(height: 24),
+                    const Text(
+                      '동승자를 평가해주세요!',
+                      style: TextStyle(fontSize: 16, fontFamily: 'jua'),
+                    ),
+                    const SizedBox(height: 12),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Color(0xFF1F355F),
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
                         ),
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => const ReviewPage()),
+                          );
+                        },
+                        child: const Text('평가하러 가기', style: TextStyle(fontSize: 14, fontFamily: 'jua', color: Colors.white)),
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
-              Align(
-                alignment: Alignment.bottomRight,
-                child: Padding(
-                  padding: const EdgeInsets.only(bottom: 390, right: 20),
-                  child: Container(
-                    width: 275,
-                    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Text(
-                          '동승자를 평가해주세요!',
-                          style: TextStyle(fontSize: 16, fontFamily: 'jua'),
-                        ),
-                        const SizedBox(height: 12),
-                        SizedBox(
-                          width: double.infinity,
-                          child: ElevatedButton(
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: const Color(0xFF1F355F),
-                              padding: const EdgeInsets.symmetric(vertical: 14),
-                              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-                            ),
-                            onPressed: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(builder: (context) => const ReviewPage()),
-                              );
-                            },
-                            child: const Text('평가하러 가기', style: TextStyle(fontSize: 14, fontFamily: 'jua', color: Colors.white)),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ],
+            ),
           ),
         );
       },

--- a/app2_client/lib/screens/party_map_screen.dart
+++ b/app2_client/lib/screens/party_map_screen.dart
@@ -76,11 +76,11 @@ class _PartyMapScreenState extends State<PartyMapScreen> {
 
   /// WebView 초기화 및 HTML 로드
   Future<void> _initWebView() async {
-    final raw = await rootBundle.loadString('assets/kakao_map.html');
+    final raw = await rootBundle.loadString('assets/kakao_party_map.html');
     final html = raw
         .replaceAll('{{KAKAO_JS_KEY}}', dotenv.env['KAKAO_JS_KEY'] ?? '')
-        .replaceAll('{{LAT}}', widget.initialLat.toString())
-        .replaceAll('{{LNG}}', widget.initialLng.toString());
+        .replaceAll('{{CENTER_LAT}}', widget.initialLat.toString())
+        .replaceAll('{{CENTER_LNG}}', widget.initialLng.toString());
 
     final wc = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
@@ -148,7 +148,7 @@ class _PartyMapScreenState extends State<PartyMapScreen> {
       return;
     }
 
-    // 지구 전체 범위의 반경을 주어 “모든 파티”를 가져오도록 설정
+    // 지구 전체 범위의 반경을 주어 "모든 파티"를 가져오도록 설정
     const extremelyLargeRadius = 20000.0; // 약 20,000km
     try {
       final list = await PartyService.fetchNearbyParties(
@@ -172,9 +172,9 @@ class _PartyMapScreenState extends State<PartyMapScreen> {
   /// _pots에 담긴 파티들을 지도 위에 마커로 찍어주는 메서드
   void _renderMarkers() {
     for (final p in _pots) {
-      _controller?.runJavaScript(
-        'addMarker("${p.id}", ${p.destLat}, ${p.destLng}, "${p.creatorName}");',
-      );
+      final js = 'addMarker("${p.id}", ${p.destLat}, ${p.destLng}, "${p.creatorName}", "blue");';
+      debugPrint('실행 JS: $js');
+      _controller?.runJavaScript(js);
     }
   }
 

--- a/app2_client/lib/services/party_service.dart
+++ b/app2_client/lib/services/party_service.dart
@@ -17,8 +17,9 @@ class PartyService {
     required double lat,
     required double lng,
     required double radiusKm,
-    required String accessToken,  // ← 토큰 인자 필수로 추가
+    required String accessToken,
   }) async {
+    print('🔍 주변 파티 조회 시작 - 위치: ($lat, $lng), 반경: ${radiusKm}km');
     final body = {
       'lat': lat,
       'lng': lng,
@@ -26,22 +27,31 @@ class PartyService {
     };
 
     try {
+      print('📡 API 요청: ${ApiConstants.partySearchEndpoint}');
       final response = await DioClient.dio.post(
         ApiConstants.partySearchEndpoint,
         data: body,
         options: Options(
           headers: {
-            'Authorization': 'Bearer $accessToken',  // ← 헤더에 토큰 넣기
+            'Authorization': 'Bearer $accessToken',
           },
         ),
       );
-      if (response.statusCode != 200) return [];
+      print('📥 응답 상태 코드: ${response.statusCode}');
+      print('📥 응답 데이터: ${response.data}');
+      
+      if (response.statusCode != 200) {
+        print('❌ 주변 파티 조회 실패: ${response.statusCode}');
+        return [];
+      }
       final List<dynamic> jsonList = response.data as List<dynamic>;
-      return jsonList
+      final parties = jsonList
           .map((e) => PartyModel.fromJson(e as Map<String, dynamic>))
           .toList();
+      print('✅ 주변 파티 ${parties.length}개 조회 성공');
+      return parties;
     } catch (e) {
-      // 에러 발생 시 빈 리스트 반환
+      print('❌ 주변 파티 조회 에러: $e');
       return [];
     }
   }
@@ -51,18 +61,35 @@ class PartyService {
     required PartyCreateRequest request,
     required String accessToken,
   }) async {
-    final body = request.toJson();
-    final response = await DioClient.dio.post(
-      ApiConstants.partyEndpoint,
-      data: body,
-      options: Options(
-        headers: {'Authorization': 'Bearer $accessToken'},
-      ),
-    );
-    if (response.statusCode != 200) {
-      throw Exception('파티 생성 실패: ${response.statusCode}');
+    print('🎉 파티 생성 시작');
+    print('📤 요청 데이터: ${request.toJson()}');
+    
+    try {
+      final body = request.toJson();
+      print('📡 API 요청: ${ApiConstants.partyEndpoint}');
+      final response = await DioClient.dio.post(
+        ApiConstants.partyEndpoint,
+        data: body,
+        options: Options(
+          headers: {'Authorization': 'Bearer $accessToken'},
+        ),
+      );
+      
+      print('📥 응답 상태 코드: ${response.statusCode}');
+      print('📥 응답 데이터: ${response.data}');
+
+      if (response.statusCode != 200) {
+        print('❌ 파티 생성 실패: ${response.statusCode}');
+        throw Exception('파티 생성 실패: ${response.statusCode}');
+      }
+      
+      final partyDetail = PartyDetail.fromJson(response.data as Map<String, dynamic>);
+      print('✅ 파티 생성 성공 - 파티 ID: ${partyDetail.partyId}');
+      return partyDetail;
+    } catch (e) {
+      print('❌ 파티 생성 에러: $e');
+      throw e;
     }
-    return PartyDetail.fromJson(response.data as Map<String, dynamic>);
   }
 
   /// 파티 참여
@@ -133,12 +160,25 @@ class PartyService {
 
   /// 내가 만든 파티 조회
   static Future<PartyDetail?> getMyParty() async {
-    final response =
-    await DioClient.dio.post("${ApiConstants.baseUrl}/api/party/my");
-    if (response.statusCode == 200) {
-      return PartyDetail.fromJson(response.data as Map<String, dynamic>);
+    print('🔍 내 파티 조회 시작');
+    try {
+      print('📡 API 요청: ${ApiConstants.baseUrl}/api/party/my');
+      final response = await DioClient.dio.post("${ApiConstants.baseUrl}/api/party/my");
+      
+      print('📥 응답 상태 코드: ${response.statusCode}');
+      print('📥 응답 데이터: ${response.data}');
+      
+      if (response.statusCode == 200) {
+        final partyDetail = PartyDetail.fromJson(response.data as Map<String, dynamic>);
+        print('✅ 내 파티 조회 성공 - 파티 ID: ${partyDetail.partyId}');
+        return partyDetail;
+      }
+      print('❌ 내 파티 조회 실패: ${response.statusCode}');
+      return null;
+    } catch (e) {
+      print('❌ 내 파티 조회 에러: $e');
+      return null;
     }
-    return null;
   }
 
   /// 파티 상세조회

--- a/app2_client/lib/widgets/party_create_modal.dart
+++ b/app2_client/lib/widgets/party_create_modal.dart
@@ -70,7 +70,7 @@ class _PartyCreateModalState extends State<PartyCreateModal> {
         accessToken: token,
       );
 
-      // 4) 디버그용으로 “생성 완료” 로그 찍기
+      // 4) 디버그용으로 "생성 완료" 로그 찍기
       debugPrint('파티 생성 성공: partyId=${party.partyId}, dest=${party.destAddress}');
 
       // 5) 모달을 닫고 MyPartyScreen으로 이동
@@ -108,117 +108,127 @@ class _PartyCreateModalState extends State<PartyCreateModal> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: SingleChildScrollView(
-        padding: EdgeInsets.only(
-          bottom: MediaQuery.of(context).viewInsets.bottom,
-          left: 16,
-          right: 16,
-          top: 24,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // ─────────────────────────────────────────────────────────────────────────
-            // (Drag Handle 표시용)
-            Container(
-              width: 40,
-              height: 4,
-              margin: const EdgeInsets.only(bottom: 16),
-              decoration: BoxDecoration(
-                color: Colors.grey[300],
-                borderRadius: BorderRadius.circular(2),
-              ),
+    return Consumer<AuthProvider>(
+      builder: (context, auth, child) {
+        final token = auth.tokens?.accessToken;
+        return SafeArea(
+          child: SingleChildScrollView(
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).viewInsets.bottom,
+              left: 16,
+              right: 16,
+              top: 24,
             ),
-
-            const Text('파티 생성',
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-            const SizedBox(height: 20),
-
-            // 출발/도착 정보 표시
-            Align(alignment: Alignment.centerLeft, child: Text('출발: ${widget.startAddress}')),
-            Align(alignment: Alignment.centerLeft, child: Text('도착: ${widget.destAddress}')),
-            const Divider(height: 32),
-
-            // 설명 입력란
-            TextField(
-              controller: _descController,
-              maxLines: 2,
-              decoration: const InputDecoration(
-                labelText: "파티 설명 (선택)",
-                hintText: "예) 서면까지 갈 사람 구해요~!",
-                border: OutlineInputBorder(),
-              ),
-            ),
-            const SizedBox(height: 20),
-
-            // ───────── 반경 설정 ─────────
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Text('반경: ${(_radius / 1000).toStringAsFixed(1)} km'),
-                Expanded(
-                  child: Slider(
-                    min: 1000,
-                    max: 10000,
-                    divisions: 9,
-                    value: _radius,
-                    label: '${(_radius / 1000).toStringAsFixed(1)} km',
-                    onChanged: (v) => setState(() => _radius = v),
+                // ─────────────────────────────────────────────────────────────────────────
+                // (Drag Handle 표시용)
+                Container(
+                  width: 40,
+                  height: 4,
+                  margin: const EdgeInsets.only(bottom: 16),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[300],
+                    borderRadius: BorderRadius.circular(2),
                   ),
                 ),
-              ],
-            ),
 
-            // ───────── 최대 인원 ─────────
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const Text('최대 인원'),
-                DropdownButton<int>(
-                  value: _maxPerson,
-                  items: [1, 2, 3, 4]
-                      .map((n) => DropdownMenuItem(value: n, child: Text('$n명')))
-                      .toList(),
-                  onChanged: (v) => setState(() => _maxPerson = v!),
+                const Text('파티 생성',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 20),
+
+                // 출발/도착 정보 표시
+                Align(alignment: Alignment.centerLeft, child: Text('출발: ${widget.startAddress}')),
+                Align(alignment: Alignment.centerLeft, child: Text('도착: ${widget.destAddress}')),
+                const Divider(height: 32),
+
+                // 설명 입력란
+                TextField(
+                  controller: _descController,
+                  maxLines: 2,
+                  decoration: const InputDecoration(
+                    labelText: "파티 설명 (선택)",
+                    hintText: "예) 서면까지 갈 사람 구해요~!",
+                    border: OutlineInputBorder(),
+                  ),
                 ),
-              ],
-            ),
+                const SizedBox(height: 20),
 
-            // ───────── 옵션 ─────────
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                const Text('팟 옵션'),
-                DropdownButton<String>(
-                  value: _option,
-                  items: const [
-                    DropdownMenuItem(value: 'MIXED', child: Text('혼성')),
-                    DropdownMenuItem(value: 'ONLY_MALE', child: Text('남성만')),
-                    DropdownMenuItem(value: 'ONLY_FEMALE', child: Text('여성만')),
+                // ───────── 반경 설정 ─────────
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text('반경: ${(_radius / 1000).toStringAsFixed(1)} km'),
+                    Expanded(
+                      child: Slider(
+                        min: 1000,
+                        max: 10000,
+                        divisions: 9,
+                        value: _radius,
+                        label: '${(_radius / 1000).toStringAsFixed(1)} km',
+                        onChanged: (v) => setState(() => _radius = v),
+                      ),
+                    ),
                   ],
-                  onChanged: (v) => setState(() => _option = v!),
                 ),
+
+                // ───────── 최대 인원 ─────────
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text('최대 인원'),
+                    DropdownButton<int>(
+                      value: _maxPerson,
+                      items: [1, 2, 3, 4]
+                          .map((n) => DropdownMenuItem(value: n, child: Text('$n명')))
+                          .toList(),
+                      onChanged: (v) => setState(() => _maxPerson = v!),
+                    ),
+                  ],
+                ),
+
+                // ───────── 옵션 ─────────
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text('팟 옵션'),
+                    DropdownButton<String>(
+                      value: _option,
+                      items: const [
+                        DropdownMenuItem(value: 'MIXED', child: Text('혼성')),
+                        DropdownMenuItem(value: 'ONLY_MALE', child: Text('남성만')),
+                        DropdownMenuItem(value: 'ONLY_FEMALE', child: Text('여성만')),
+                      ],
+                      onChanged: (v) => setState(() => _option = v!),
+                    ),
+                  ],
+                ),
+
+                const SizedBox(height: 28),
+
+                // ───────── 생성 버튼 ─────────
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: _submitting || token == null ? null : _submit,
+                    style: ElevatedButton.styleFrom(padding: const EdgeInsets.symmetric(vertical: 14)),
+                    child: _submitting
+                        ? const CircularProgressIndicator(color: Colors.white)
+                        : const Text('생성하기'),
+                  ),
+                ),
+                if (token == null)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 12),
+                    child: Text('로그인이 필요합니다.', style: TextStyle(color: Colors.red)),
+                  ),
+                const SizedBox(height: 12),
               ],
             ),
-
-            const SizedBox(height: 28),
-
-            // ───────── 생성 버튼 ─────────
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: _submitting ? null : _submit,
-                style: ElevatedButton.styleFrom(padding: const EdgeInsets.symmetric(vertical: 14)),
-                child: _submitting
-                    ? const CircularProgressIndicator(color: Colors.white)
-                    : const Text('생성하기'),
-              ),
-            ),
-            const SizedBox(height: 12),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/app2_client/pubspec.lock
+++ b/app2_client/pubspec.lock
@@ -513,6 +513,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  overlay_support:
+    dependency: "direct main"
+    description:
+      name: overlay_support
+      sha256: fc39389bfd94e6985e1e13b2a88a125fc4027608485d2d4e2847afe1b2bb339c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   path:
     dependency: transitive
     description:

--- a/app2_client/pubspec.yaml
+++ b/app2_client/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
       url: https://github.com/lepitaaar/flutter_sms.git
       ref: master
 
+  overlay_support: ^2.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## PR: 파티 지도 기능 개선 및 UX 향상

### 1. Provider(토큰) 구조 개선
- 앱 시작 시 `FlutterSecureStorage`에서 토큰을 읽어 `AuthProvider`에 세팅하도록 구조 개선
- Provider 중복 생성 문제 해결
  - `main.dart`에서만 `ChangeNotifierProvider` 생성
  - `app.dart`에서는 Provider 제거

---

### 2. 파티 데이터 파싱 및 마커 표시
- 서버 응답(snake_case)에 맞춰 `PartyModel` 파싱 로직 수정
- 파티 리스트 정상 조회 및 파싱 에러 해결

---

### 3. 지도 마커 표시 및 JS 연동
- `WebView`에서 `kakao_party_map.html` 로드하도록 수정  
  - `addMarker()` 함수 포함된 버전으로 교체
- 마커 표시 시 다음 기능 반영:
  - `color` 파라미터 추가 (`"blue"`, `"red"` 등)
  - 마커 크기 **64x96**으로 확대하여 시인성 향상
- 마커 클릭 시 Flutter로 이벤트 전달
  - `window.MarkerClick.postMessage(id)` 방식 사용 (`webview_flutter` 호환)

---

### 4. 파티 참여 UX 개선
- 파티 참여 중복 신청 시:
  - `409 Conflict` 응답을 감지하여 `"이미 참여중인 파티입니다."` 메시지 표시
- `overlay_support` 패키지 적용:
  - `SnackBar` 대신 `showSimpleNotification()` 사용
  - 알림이 **항상 화면 최상단**에 표시되도록 변경 (모달에 가리지 않음)

---

### 5. 기타 개선 사항
- JS 템플릿에서 `centerLat`/`centerLng` 값 파싱 오류 방지
  - `parseFloat()` 사용 및 `console.log`로 디버깅 로그 추가
- `addMarker()` 실행 시 콘솔 로그 출력 → 마커 디버깅 용이