### PR TITLE
파티 참여 요청/수락 UI 및 로직 서버 명세에 맞게 개선

### DIFF
--- a/app2_client/lib/models/join_request_model.dart
+++ b/app2_client/lib/models/join_request_model.dart
@@ -1,16 +1,14 @@
 // MyPartyScreen.dart 내부에 inline으로 정의된 JoinRequest
 class JoinRequest {
   final int requestId;
-  final String userName;
-  final String userEmail;
+  final String requesterEmail;
 
-  JoinRequest({required this.requestId, required this.userName, required this.userEmail});
+  JoinRequest({required this.requestId, required this.requesterEmail});
 
   factory JoinRequest.fromJson(Map<String, dynamic> json) {
     return JoinRequest(
-      requestId: json['request_id'],
-      userName: json['name'],
-      userEmail: json['email'],
+      requestId: json['requestId'] ?? json['request_id'],
+      requesterEmail: json['requesterEmail'],
     );
   }
 }


### PR DESCRIPTION
📋 변경 목적

파티 참여 요청 시 호스트 화면에 수락/거절 버튼이 안 뜨고,
참여자가 바로 파티원 목록에 표시되는 문제 해결
서버 명세에 맞는 데이터 구조로 파싱 및 UI 표시
파티원 목록에 status == 'ACCEPTED'인 멤버만 표시

🛠️ 주요 변경점

JoinRequest 모델 서버 명세에 맞게 수정
userName, userEmail 필드 제거
requesterEmail만 사용하도록 변경
파싱 시 requestId(또는 request_id), requesterEmail만 사용
MyPartyScreen 참여 요청 UI 개선
참여 요청 리스트에 이메일만 표시
수락/거절 버튼 정상 노출
디버그 정보도 이메일 기준으로 변경
파티원 목록 표시 조건 추가
status == 'ACCEPTED'인 멤버만 파티원 목록에 표시
