### PR TITLE
[Feature] 리뷰 페이지 연동

### DIFF
--- a/app2_client/lib/screens/home_star.dart
+++ b/app2_client/lib/screens/home_star.dart
@@ -1,23 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
-
-void main() => runApp(const MaterialApp(home: ReviewPage(), debugShowCheckedModeBanner: false));
+import 'package:app2_client/services/review_service.dart';
 
 class ReviewPage extends StatefulWidget {
-  const ReviewPage({super.key});
+  final int partyId; //외부에서 받아온 partyId 저장
+  const ReviewPage({super.key, required this.partyId});
 
   @override
   State<ReviewPage> createState() => _ReviewPageState();
 }
 
 class _ReviewPageState extends State<ReviewPage> {
-  final List<Map<String, dynamic>> members = [
-    {'name': '김*서', 'role': '방장'},
-    {'name': '김*서', 'role': '팀원'},
-    {'name': '김*서', 'role': '팀원'},
-    {'name': '김*서', 'role': '팀원'},
-    {'name': '김*서', 'role': '팀원'},
-  ];
+  List<Map<String, dynamic>> members = []; // 1. /api/unreview → 리뷰 대상자 가져오기
+  final Map<int, double> ratings = {}; // 2. 각 멤버에 대해 리뷰 입력 받기
+  final Map<int, Set<String>> selectedTags = {};
 
   final List<String> allTags = [
     '시간 엄수', '소통 원활', '친절한 태도',
@@ -25,143 +21,93 @@ class _ReviewPageState extends State<ReviewPage> {
     '굿 매너', '재탑승 희망', '매너 정산러',
   ];
 
-  final Map<int, double> ratings = {};
-  final Map<int, Set<String>> selectedTags = {};
+  String maskName(String name) {
+    if (name.length <= 2) return name;
+    return name[0] + '*' + name.substring(2);
+  } // 가운데 이름 => 마스킹 * 처리
+
+  @override
+  void initState() {
+    super.initState();
+    fetchMembers(); // 1. 진입 시 리뷰 대상자 호출
+  }
+
+  Future<void> fetchMembers() async {
+    final result = await ReviewService.getUnreviewTargets();
+    setState(() {
+      members = result.map((e) =>
+      {
+        'name': e['name'],
+        'role': e['memberRole'] == 'HOST' ? '방장' : '팀원',
+        'email': e['email'],
+      }).toList();
+    });
+  }
+
+  Future<void> submitReviews() async {
+    for (int i = 0; i < members.length; i++) {
+      final email = members[i]['email'];
+      final score = ratings[i] ?? 0;
+      final tags = selectedTags[i]?.toList() ?? [];
+
+      final message = await ReviewService
+          .submitReview( // 3. /api/{email}/review POST 요청
+        email: email,
+        partyId: widget.partyId,
+        score: score,
+        tags: tags,
+      );
+
+      if (message == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('$email 리뷰 제출 실패')),
+        );
+        return;
+      }
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('모든 리뷰가 제출되었습니다.')),
+    );
+    Navigator.pop(context);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
       appBar: AppBar(title: const Text('파티원 평가하기')),
-      body: Scrollbar( // ✅ 스크롤바 추가
-        thumbVisibility: true, // 항상 보이게
+      body: members.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : Scrollbar(
+        thumbVisibility: true,
         child: ListView.builder(
-          padding: const EdgeInsets.only(bottom: 100), // ✅ 버튼 안 가리도록 여백 추가
+          padding: const EdgeInsets.only(bottom: 100),
           itemCount: members.length,
           itemBuilder: (context, index) {
             final member = members[index];
 
             return Padding(
-              padding: const EdgeInsets.all(16.0),
+              padding: const EdgeInsets.all(16),
               child: Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
                   color: Colors.white,
                   borderRadius: BorderRadius.circular(16),
                   boxShadow: const [
-                    BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(0, 2)),
+                    BoxShadow(
+                      color: Colors.black12,
+                      blurRadius: 4,
+                      offset: Offset(0, 2),
+                    ),
                   ],
                 ),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // 이름 + 역할 + 별점
-                    Row(
-                      children: [
-                        const CircleAvatar(radius: 20, backgroundColor: Colors.grey),
-                        const SizedBox(width: 20),
-                        Text(member['name'],
-                            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                        const SizedBox(width: 17),
-                        Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                          decoration: BoxDecoration(
-                            color: const Color(0xFFF6C651),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: Text(
-                            member['role'],
-                            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        RatingBar.builder(
-                          initialRating: ratings[index] ?? 0,
-                          itemSize: 30,
-                          minRating: 0,
-                          allowHalfRating: false,
-                          itemBuilder: (_, __) => const Icon(Icons.star, color: Colors.amber),
-                          unratedColor: Colors.grey.shade300,
-                          onRatingUpdate: (value) {
-                            setState(() {
-                              ratings[index] = value;
-                            });
-                          },
-                        ),
-                      ],
-                    ),
+                    _buildHeader(member, index),
                     const SizedBox(height: 20),
-
-                    // 후기 키워드 전체 행
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // "후기 키워드" 박스
-                        Container(
-                          margin: const EdgeInsets.only(right: 12),
-                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                          decoration: BoxDecoration(
-                            color: const Color(0xFF1F355F),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: const Text(
-                            '후기 키워드',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 11,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
-                        // 키워드들 세 줄 정렬
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: List.generate(3, (rowIndex) {
-                              final tagsForRow = allTags.skip(rowIndex * 3).take(3).toList();
-                              return Padding(
-                                padding: const EdgeInsets.only(bottom: 8),
-                                child: Row(
-                                  children: tagsForRow.map((tag) {
-                                    final selected = selectedTags[index]?.contains(tag) ?? false;
-                                    return GestureDetector(
-                                      onTap: () {
-                                        setState(() {
-                                          selectedTags[index] ??= {};
-                                          if (selected) {
-                                            selectedTags[index]!.remove(tag);
-                                          } else {
-                                            selectedTags[index]!.add(tag);
-                                          }
-                                        });
-                                      },
-                                      child: Container(
-                                        margin: const EdgeInsets.only(right: 8),
-                                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-                                        decoration: BoxDecoration(
-                                          color: selected ? const Color(0xFFEAF1FB) : Colors.grey.shade200,
-                                          borderRadius: BorderRadius.circular(20),
-                                          border: selected
-                                              ? Border.all(color: const Color(0xFF5271FF), width: 1.5)
-                                              : null,
-                                        ),
-                                        child: Text(
-                                          '#$tag',
-                                          style: TextStyle(
-                                            fontSize: 11,
-                                            color: selected ? const Color(0xFF1F355F) : Colors.grey,
-                                            fontWeight: selected ? FontWeight.bold : FontWeight.normal,
-                                          ),
-                                        ),
-                                      ),
-                                    );
-                                  }).toList(),
-                                ),
-                              );
-                            }),
-                          ),
-                        ),
-                      ],
-                    ),
+                    _buildKeywordSection(index),
                   ],
                 ),
               ),
@@ -169,17 +115,12 @@ class _ReviewPageState extends State<ReviewPage> {
           },
         ),
       ),
-
-      // ✅ 하단 제출 버튼
       bottomNavigationBar: Padding(
-        padding: const EdgeInsets.all(16.0),
+        padding: const EdgeInsets.all(16),
         child: ElevatedButton(
-          onPressed: () {
-            // TODO: 제출 로직 작성
-            print('제출됨!');
-          },
+          onPressed: submitReviews,
           style: ElevatedButton.styleFrom(
-            backgroundColor: const Color(0xFF1F355F),
+            backgroundColor: const Color(0xFF003366),
             padding: const EdgeInsets.symmetric(vertical: 16),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
@@ -187,10 +128,121 @@ class _ReviewPageState extends State<ReviewPage> {
           ),
           child: const Text(
             '평가 제출하기',
-            style: TextStyle(fontSize: 16, fontFamily: 'jua', color: Colors.white),
+            style: TextStyle(
+                fontSize: 16, color: Colors.white),
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildHeader(Map<String, dynamic> member, int index) {
+    return Row(
+      children: [
+        const CircleAvatar(radius: 20, backgroundColor: Colors.grey),
+        const SizedBox(width: 20),
+        Text(maskName(member['name']),
+            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+        const SizedBox(width: 17),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: const Color(0xFFFFCC33),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Text(
+            member['role'],
+            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+          ),
+        ),
+        const SizedBox(width: 8),
+        RatingBar.builder(
+          initialRating: ratings[index] ?? 0,
+          itemSize: 30,
+          minRating: 0,
+          allowHalfRating: true,
+          itemBuilder: (_, __) => const Icon(Icons.star, color: Colors.amber),
+          unratedColor: Colors.grey.shade300,
+          onRatingUpdate: (value) => setState(() => ratings[index] = value),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildKeywordSection(int index) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          margin: const EdgeInsets.only(right: 12),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          decoration: BoxDecoration(
+            color: const Color(0xFF003366),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: const Text(
+            '후기 키워드',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 11,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: List.generate(3, (rowIndex) {
+              final tagsForRow = allTags.skip(rowIndex * 3).take(3).toList();
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Row(
+                  children: tagsForRow.map((tag) {
+                    final selected = selectedTags[index]?.contains(tag) ??
+                        false;
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          selectedTags[index] ??= {};
+                          if (selected) {
+                            selectedTags[index]!.remove(tag);
+                          } else {
+                            selectedTags[index]!.add(tag);
+                          }
+                        });
+                      },
+                      child: Container(
+                        margin: const EdgeInsets.only(right: 8),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: selected ? const Color(0xFFEAF1FB) : Colors
+                              .grey.shade200,
+                          borderRadius: BorderRadius.circular(20),
+                          border: selected
+                              ? Border.all(
+                              color: const Color(0xFF5271FF), width: 1.5)
+                              : null,
+                        ),
+                        child: Text(
+                          '#$tag',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: selected ? const Color(0xFF1F355F) : Colors
+                                .grey,
+                            fontWeight: selected ? FontWeight.bold : FontWeight
+                                .normal,
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                ),
+              );
+            }),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/app2_client/lib/services/review_service.dart
+++ b/app2_client/lib/services/review_service.dart
@@ -1,0 +1,49 @@
+import 'package:app2_client/services/dio_client.dart';
+import 'package:flutter/foundation.dart';
+
+class ReviewService {
+  /// 리뷰 안 한 멤버 목록 가져오기
+  static Future<List<Map<String, dynamic>>> getUnreviewTargets() async {
+    try {
+      final response = await DioClient.dio.get('/api/unreview');
+      if (response.statusCode == 200) {
+        return List<Map<String, dynamic>>.from(response.data);
+      } else {
+        debugPrint('🔴 리뷰 대상자 불러오기 실패: ${response.statusCode}');
+        return [];
+      }
+    } catch (e) {
+      debugPrint('❌ 예외 발생: $e');
+      return [];
+    }
+  }
+
+  /// 리뷰 제출하기
+  static Future<String?> submitReview({
+    required String email,
+    required int partyId,
+    required double score,
+    required List<String> tags,
+  }) async {
+    try {
+      final response = await DioClient.dio.post(
+        '/api/$email/review',
+        data: {
+          'party_id': partyId,
+          'score': score,
+          'tags': tags,
+        },
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        return response.data['message'];
+      } else {
+        debugPrint('🔴 리뷰 작성 실패: ${response.statusCode} ${response.data}');
+        return null;
+      }
+    } catch (e) {
+      debugPrint('❌ 리뷰 작성 예외: $e');
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
리뷰작성하는 곳이 마이페이지에서 정산페이지로 이동되었습니다
연동코드 일단 작성한 리뷰페이지 올립니다.

● 1. 리뷰대상자 불러오기
* /api/unreview <GET> 사용
- review_service.dart 생성
- ReviewPage에서 initState에 fetchMemebers() 실행
-  ReviewService.getUnreviewTargets() 함수로 GET

● 2. 리뷰 입력
* /api/{email}/review <POST> 사용
- ReviewService.submitReview() 함수로 POST 요청 : 평가 제출하기 버튼 누르면 호출됨 —>> 이때 POST 조건이 partyId를 서버에 보내야 되는데, partyId를 앞 페이지에서 받는걸로 했습니다.

정산페이지에서
Navigator.push(
  context,
  MaterialPageRoute(
    builder: (_) => ReviewPage(partyId: partyId),
  ),
);